### PR TITLE
プリセット登録ページのバグ修正

### DIFF
--- a/register/api/setPreset.php
+++ b/register/api/setPreset.php
@@ -52,7 +52,7 @@ function setPreset($post, $imagePath = '') {
 
         // 画像がアップロードされた場合、リネームとサムネイル抽出を行い特定フォルダに保存
         $imageFileName = $imagePath;
-        if ($post['from'] === 'saver' && !isset($presets['image']) && $_FILES['image']['name'] !== '') $imageFileName = setImages();
+        if ($post['from'] === 'saver' && $imagePath === '') $imageFileName = setImages();
     
         if (isset($_GET['preset_id'])) {
             $sql = <<<SQL

--- a/register/api/setPreset.php
+++ b/register/api/setPreset.php
@@ -45,14 +45,14 @@ function setImages() {
     return $imageFileName;
 }
 
-function setPreset($post) {
+function setPreset($post, $imagePath = '') {
     try {
         $pdo = dbConnect();
         $pdo->beginTransaction();
 
         // 画像がアップロードされた場合、リネームとサムネイル抽出を行い特定フォルダに保存
-        $imageFileName = isset($presets['image']) ? $presets['image'] : '';
-        if ($post['from'] === 'saver' && $_FILES['image']['name'] !== '') $imageFileName = setImages();
+        $imageFileName = $imagePath;
+        if ($post['from'] === 'saver' && !isset($presets['image']) && $_FILES['image']['name'] !== '') $imageFileName = setImages();
     
         if (isset($_GET['preset_id'])) {
             $sql = <<<SQL

--- a/register/commands.php
+++ b/register/commands.php
@@ -236,7 +236,9 @@ $canonical = "https://nai-pg.com/register/";
                 </div>
                 <input type="hidden" name="cToken" value="<?= $cToken ?>">
                 <input type="hidden" name="from" value="saver">
+                <?php if ($_SERVER['REQUEST_METHOD'] !== 'POST') { ?>
                 <input type="submit" value="<?= isset($_GET['preset_id']) ? '更新' : '登録' ?>" class="btn-common submit">
+                <?php } ?>
             </dl>
         </form>
         <div class="preview">

--- a/register/commands.php
+++ b/register/commands.php
@@ -65,7 +65,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (DEBUG) echo $e;
         }
     } else {
-        $response = setPreset($_POST);
+        $response = setPreset($_POST, isset($presets['image']) ? $presets['image'] : '');
         $message[] = $response['message'];
         $imageFileName = $response['imagePath'];
 

--- a/register/commands.php
+++ b/register/commands.php
@@ -58,7 +58,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $st->execute();
 
             $pdo->commit();
-            header('location: ./', true, 303);
+            header('location: ../#/saves/', true, 303);
             exit;
         } catch (PDOException $e) {
             echo 'データベース接続に失敗しました。';


### PR DESCRIPTION
- データ削除時に新トップページにリダイレクトするよう変更
- データ更新時に画像が消える問題の修正(API送信時にPathが正しく送られてなかった)
- データ二重登録ができない(画面更新されず固まる)問題の暫定対処(POST時は登録ボタンを非表示にした)