### PR TITLE
プロンプト設定欄の別コンポーネント化、全体のリファクタリング

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,8 @@
     <meta property="og:title" content="NovelAI プロンプトジェネレーター">
     <style>
         body {
-            margin: 0;
+            max-width: 1560px;
+            margin: 0 auto;
             font-family: 'Yu Gothic Medium', '游ゴシック Medium', sans-serif;
             box-sizing: border-box;
             position: relative;

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -227,7 +227,7 @@ export default {
             // カラータグが存在する場合はタグ名と表示名を上書き
             if (colorTag !== '' && colorTagJP !== '') {
                 queue.tag = colorTag
-                queue.jp = queue.jp + + ' (' + colorTagJP + ')'
+                queue.jp = queue.jp + ' (' + colorTagJP + ')'
             }
 
             setPrompt.value.push(queue)

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -1,76 +1,72 @@
 <template>
-    <div class="top-content">
-        <div class="main">
-            <HeaderComponent :user="user_id"></HeaderComponent>
-            <div class="content">
-                <div class="main-content">
-                    <section class="user-setting-area">
-                        <div class="upload-prompt">
-                            <label :id="'upload-prompt'">プロンプトをアップロード</label>
-                            <input type="text" :id="'upload-prompt'" v-model="uploadPromptInput" @keyup.enter="uploadPrompt(uploadPromptInput)">
-                            <button @click="uploadPrompt(uploadPromptInput)" class="btn-common green">アップロード</button>
-                        </div>
-                        <div class="toggle-nsfw">
-                            <button @click="toggleDisplayNsfw('C')" v-show="displayNsfw === 'A'" class="btn-common blue">全年齢</button>
-                            <button @click="toggleDisplayNsfw('Z')" v-show="displayNsfw === 'C'" class="btn-common green">R-15</button>
-                            <button @click="toggleDisplayNsfw('A')" v-show="displayNsfw === 'Z'" class="btn-common pink">R-18</button>            
-                        </div>
-                    </section>
-                    <section class="tag-list">
-                        <div 
-                            class="spell-list"
-                            v-for="(genre, i) in promptList"                 
-                            :key="genre.slag"
-                            :style="[genre.display ? 'display:block' : 'display:none']"
-                        >
-                            <div class="description">
-                                <div>
-                                    <p class="genre">{{ genre.jp }}</p>
-                                    <p class="caption">{{ genre.caption }}</p>
-                                </div>
-                                <div>
-                                    <span @click="promptList[i]['show_all'] = true" v-if="!promptList[i]['show_all']">▼</span>
-                                    <span @click="promptList[i]['show_all'] = false" v-if="promptList[i]['show_all']">▲</span>
-                                </div>
-                            </div>
-                            <div :style="[promptList[i]['show_all'] ? 'max-height:none;' : 'max-height:240px;']">
-                                <div 
-                                    v-for="(prompt, j) in genre.content" 
-                                    :key="prompt.slag" 
-                                    :style="[prompt.display ? 'display:block; position:relative;' : 'display:none']">
-                                    <button 
-                                        :class="[
-                                            prompt.selected ? 'btn-toggle selected' : 'btn-toggle', 
-                                            'nsfw_' + prompt.nsfw
-                                        ]" 
-                                        @click="toggleSetPromptList(i, j)"
-                                        @mouseover="hoverPromptName = prompt.tag"
-                                        @mouseleave="hoverPromptName = ''"
-                                    >
-                                    {{ prompt.jp }}
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
+    <HeaderComponent :user="user_id"></HeaderComponent>
+    <main class="content">
+        <div class="prompt-list">
+            <section class="user-setting-area">
+                <div class="upload-prompt">
+                    <label :id="'upload-prompt'">プロンプトをアップロード</label>
+                    <input type="text" :id="'upload-prompt'" v-model="uploadPromptInput" @keyup.enter="uploadPrompt(uploadPromptInput)">
+                    <button @click="uploadPrompt(uploadPromptInput)" class="btn-common green">アップロード</button>
                 </div>
-                <SetPromptComponent 
-                    :setPromptList="setPrompt"
-                    :hoverPromptName="hoverPromptName"
-                    @updateSetPrompt="updateSetPrompt"
-                    @addManualPrompt="addManualPrompt"
-                    @unSelectedPrompt="unSelectedPrompt"
-                    @openSaveModal="openSaveModal"
-                />
-            </div>
+                <div class="toggle-nsfw">
+                    <button @click="toggleDisplayNsfw('C')" v-show="displayNsfw === 'A'" class="btn-common blue">全年齢</button>
+                    <button @click="toggleDisplayNsfw('Z')" v-show="displayNsfw === 'C'" class="btn-common green">R-15</button>
+                    <button @click="toggleDisplayNsfw('A')" v-show="displayNsfw === 'Z'" class="btn-common pink">R-18</button>            
+                </div>
+            </section>
+            <section class="prompt-list-area">
+                <div 
+                    class="prompt-list-genre"
+                    v-for="(genre, i) in promptList"                 
+                    :key="genre.slag"
+                    :style="[genre.display ? 'display:block' : 'display:none']"
+                >
+                    <div class="description">
+                        <div>
+                            <p class="genre">{{ genre.jp }}</p>
+                            <p class="caption">{{ genre.caption }}</p>
+                        </div>
+                        <div>
+                            <span @click="promptList[i]['show_all'] = true" v-if="!promptList[i]['show_all']">▼</span>
+                            <span @click="promptList[i]['show_all'] = false" v-if="promptList[i]['show_all']">▲</span>
+                        </div>
+                    </div>
+                    <div :style="[promptList[i]['show_all'] ? 'max-height:none;' : 'max-height:240px;']" class="prompt-list-prompt">
+                        <div 
+                            v-for="(prompt, j) in genre.content" 
+                            :key="prompt.slag" 
+                            :style="[prompt.display ? 'display:block' : 'display:none']">
+                            <button 
+                                :class="[
+                                    prompt.selected ? 'btn-toggle selected' : 'btn-toggle', 
+                                    'nsfw_' + prompt.nsfw
+                                ]" 
+                                @click="toggleSetPromptList(i, j)"
+                                @mouseover="hoverPromptName = prompt.tag"
+                                @mouseleave="hoverPromptName = ''"
+                            >
+                            {{ prompt.jp }}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </section>
         </div>
-        <ModalDBComponent
-            :prompts="outputPrompt"
-            :displayModalState="isOpenSaveModal"
-            @updateModal="updateModalState"
-            :style="[isOpenSaveModal ? 'display: block' : 'display: none']"
+        <SetPromptComponent 
+            :setPromptList="setPrompt"
+            :hoverPromptName="hoverPromptName"
+            @updateSetPrompt="updateSetPrompt"
+            @addManualPrompt="addManualPrompt"
+            @unSelectedPrompt="unSelectedPrompt"
+            @openSaveModal="openSaveModal"
         />
-    </div>
+    </main>
+    <ModalDBComponent
+        :prompts="outputPrompt"
+        :displayModalState="isOpenSaveModal"
+        @updateModal="updateModalState"
+        :style="[isOpenSaveModal ? 'display: block' : 'display: none']"
+    />
     <router-view></router-view>
 </template>
 

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -313,10 +313,8 @@ export default {
         }
 
         // 子コンポーネントから伝えられたプロンプト設定欄の内容を更新
-        const updateSetPrompt = (childSetPrompt: {[key: string]: any}[]) => {
-            setPrompt.value = childSetPrompt
-        }
-
+        const updateSetPrompt = (childSetPrompt: {[key: string]: any}[]) => setPrompt.value = childSetPrompt
+        
         // セットキューから指定したプロンプトを削除
         const unSelectedPrompt = (promptListIndex: string): void => {
             const tagsIndexList = promptListIndex.split(',')
@@ -328,17 +326,17 @@ export default {
 
         // DB保存モーダルの表示可否
         const isOpenSaveModal = ref<boolean>(false)
+        // モーダルの表示状態を更新する
+        const updateModalState = (isDisplay: boolean): boolean => isOpenSaveModal.value = isDisplay
+
         const outputPrompt = ref<string>('')
         // DB保存用のモーダルを開く
         const openSaveModal = (modalState: boolean, output: string): void => {
             outputPrompt.value = output
-            isOpenSaveModal.value = modalState
+            updateModalState(modalState)
         }
         
-        // モーダルの表示状態を更新する
-        const updateModalState = (isDisplay: boolean): boolean => isOpenSaveModal.value = isDisplay
-
-        // 画面読み込み時にマスタデータ一覧を取得、できなかった場合ローカルのjsファイルから取得
+        // DBからマスタデータ一覧を取得、できなかった場合ローカルのjsファイルから取得
         const getMasterData = async(): Promise<void> => {
             const url = registerPath + 'api/getMasterData.php?from=spell_generator'
             await axios.get(url)

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -356,6 +356,7 @@ export default {
 
         // 画面読み込み時、ログインユーザーIDを取得し、DBからマスタデータを取得。できない場合はローカルから取得。
         onMounted(() => {
+            document.title = 'NovelAI プロンプトジェネレーター'
             getUserInfo()
             getMasterData()
         })

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -61,7 +61,7 @@
                         <div class="manual-input-area">
                             <label :for="'manual-input'">手動追加</label>
                             <input type="text" :id="'manual-input'" v-model="manualInput">
-                            <button class="btn-common green" @click="addManualPromptToList(manualInput)">追加</button>
+                            <button class="btn-common green" @click="addManualPrompt(manualInput)">追加</button>
                         </div>
                     </div>
                     <draggable 
@@ -97,7 +97,7 @@
                                     <button @click="setSpells[index].enhance += 1" class="btn-common green">＋</button>
                                 </div>
                                 <div class="delete-area">
-                                    <button @click="deleteSetPromptList(index)" class="btn-common red">削除</button>
+                                    <button @click="deleteSetPrompt(index)" class="btn-common red">削除</button>
                                 </div>
                             </div>
                         </template>
@@ -149,7 +149,7 @@ import axios from 'axios'
 import draggable from 'vuedraggable'
 import './assets/scss/promptGenerator.scss'
 import HeaderComponent from './components/HeaderComponent.vue'
-import ModalDBComponent from './components/ModalDBComponent.vue'
+import ModalDBComponent from './components/generator/ModalDBComponent.vue'
 
 export default {
     components: {
@@ -252,7 +252,7 @@ export default {
         }
 
         // 手動入力でのプロンプトの追加
-        const addManualPromptToList = (input: string, enhanceCount: number = 0): void => {
+        const addManualPrompt = (input: string, enhanceCount: number = 0): void => {
             let isAlreadySetPrompt = false
             // 既に追加されているプロンプト名の場合追加しない
             setSpells.value.map((prompt: {[key: string]: any}) => {
@@ -334,7 +334,7 @@ export default {
                     } 
                 }
             }
-            addManualPromptToList(tagname, enhanceCount)
+            addManualPrompt(tagname, enhanceCount)
             return
         }
 
@@ -422,7 +422,7 @@ export default {
         } 
 
         // セットキューから指定したプロンプトを削除
-        const deleteSetPromptList = (index: number): void => {
+        const deleteSetPrompt = (index: number): void => {
             if (setSpells.value[index].index !== null) {
                 const tagsIndexList = setSpells.value[index].index.split(',')
                 const i = parseInt(tagsIndexList[0])
@@ -526,8 +526,8 @@ export default {
             toggleSetPromptList,
             toggleDisplayNsfw,
             changePromptColor,
-            addManualPromptToList,
-            deleteSetPromptList,
+            addManualPrompt,
+            deleteSetPrompt,
             convertToNovelAITags,
             toggleEnhanceBrace,
             openSaveModal,

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -11,9 +11,9 @@
                             <button @click="uploadPrompt(uploadPromptInput)" class="btn-common green">アップロード</button>
                         </div>
                         <div class="toggle-nsfw">
-                            <button @click="toggleDisplayNsfw('C')" v-if="displayNsfw === 'A'" class="btn-common blue">全年齢</button>
-                            <button @click="toggleDisplayNsfw('Z')" v-if="displayNsfw === 'C'" class="btn-common green">R-15</button>
-                            <button @click="toggleDisplayNsfw('A')" v-if="displayNsfw === 'Z'" class="btn-common pink">R-18</button>            
+                            <button @click="toggleDisplayNsfw('C')" v-show="displayNsfw === 'A'" class="btn-common blue">全年齢</button>
+                            <button @click="toggleDisplayNsfw('Z')" v-show="displayNsfw === 'C'" class="btn-common green">R-15</button>
+                            <button @click="toggleDisplayNsfw('A')" v-show="displayNsfw === 'Z'" class="btn-common pink">R-18</button>            
                         </div>
                     </section>
                     <section class="tag-list">

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -150,8 +150,6 @@ export default {
                 commandList.push(genre)
             })
 
-            // プロンプト一覧における個々の表示状態を設定
-            setDisplayNsfw(displayNsfw.value)
             return commandList
         }
 
@@ -340,9 +338,13 @@ export default {
         const getMasterData = async(): Promise<void> => {
             const url = registerPath + 'api/getMasterData.php?from=spell_generator'
             await axios.get(url)
-                .then(response => promptList.value = convertJsonToTagList(response.data))
+                .then(response => { 
+                    promptList.value = convertJsonToTagList(response.data)
+                    setDisplayNsfw(displayNsfw.value)
+                })
                 .catch(error => {
                     promptList.value = convertJsonToTagList(JSON.parse(master_data))
+                    setDisplayNsfw(displayNsfw.value)
                     console.log(error)
                 })
         }

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -227,7 +227,7 @@ export default {
 
             // カラータグが存在する場合はタグ名と表示名を上書き
             if (colorTag !== '' && colorTagJP !== '') {
-                queue.tag = colorTag
+                queue.output_prompt = colorTag + ' ' + queue.tag
                 queue.jp = queue.jp + ' (' + colorTagJP + ')'
             }
 

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -276,8 +276,8 @@ export default {
         }
 
         // 既存のタグがアップロードされた場合、セットキューに対象値を追加
-        const uploadPrompt = (spell: string): void => {
-            if (spell.trim() === '') return
+        const uploadPrompt = (inputPromptList: string): void => {
+            if (inputPromptList.trim() === '') return
             // 既存の設定プロンプトリストと手動入力欄をリセット
             setPrompt.value = []
             manualInput.value = ''
@@ -288,7 +288,7 @@ export default {
             })
 
             // タグごと配列の要素にする
-            const uploadedPromptList = spell.split(',').map(tag => tag.trim())
+            const uploadedPromptList = inputPromptList.split(',').map(tag => tag.trim())
             uploadedPromptList.map((prompt: string, index: number) => {
                 if(prompt.trim() === "") {
                     uploadedPromptList.splice(index, 1)

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -210,6 +210,40 @@ export default {
             }
         }
 
+        // タグのセットキューに挿入
+        const toggleSetPromptList = (i: number, j: number): void => { 
+            const queue = promptList.value[i].content[j]
+            
+            queue['output_prompt'] = queue.tag
+            queue['enhance'] = 0
+            switch (promptList.value[i].content[j].variation) {
+                case 'CC':
+                    queue['color_list'] = colorMulti
+                    break
+                case 'CM':
+                    queue['color_list'] = colorMono
+                    break
+                default:
+                    queue['color_list'] = null
+                    break
+            }
+            const selected = promptList.value[i].content[j].selected
+
+            if (!selected) {
+                if (!setPrompt.value.includes(queue)) {
+                    setPrompt.value.push(queue)
+                    promptList.value[i].content[j].selected = true
+                }
+            } else {
+                for (let index = 0; index < setPrompt.value.length; index++) {
+                    if (setPrompt.value[index].tag === queue.tag) {
+                        setPrompt.value.splice(index, 1)
+                        promptList.value[i].content[j].selected = false
+                    }
+                }
+            }
+        }
+        
         // タグ一覧から指定のタグ名を検索し、親タグと日本語名を返す
         const setPromptFromUploadText = (tagname: string, enhanceCount: number): void => {            
             // カラーリング付プロンプト用の定数。AfterSpaceがプロンプト名本体、BeforSpaceがカラーバリュー。
@@ -308,40 +342,6 @@ export default {
                     setPromptFromUploadText(tagname, enhanceCount.value)      
                 }
             })
-        }
-
-        // タグのセットキューに挿入
-        const toggleSetPromptList = (i: number, j: number): void => { 
-            const queue = promptList.value[i].content[j]
-            
-            queue['output_prompt'] = queue.tag
-            queue['enhance'] = 0
-            switch (promptList.value[i].content[j].variation) {
-                case 'CC':
-                    queue['color_list'] = colorMulti
-                    break
-                case 'CM':
-                    queue['color_list'] = colorMono
-                    break
-                default:
-                    queue['color_list'] = null
-                    break
-            }
-            const selected = promptList.value[i].content[j].selected
-
-            if (!selected) {
-                if (!setPrompt.value.includes(queue)) {
-                    setPrompt.value.push(queue)
-                    promptList.value[i].content[j].selected = true
-                }
-            } else {
-                for (let index = 0; index < setPrompt.value.length; index++) {
-                    if (setPrompt.value[index].tag === queue.tag) {
-                        setPrompt.value.splice(index, 1)
-                        promptList.value[i].content[j].selected = false
-                    }
-                }
-            }
         }
 
         // 子コンポーネントから伝えられたプロンプト設定欄の内容を更新

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -59,7 +59,7 @@
                     :hoverPromptName="hoverPromptName"
                     @updateSetPrompt="updateSetPrompt"
                     @addManualPrompt="addManualPrompt"
-                    @deleteSetPrompt="deleteSetPrompt"
+                    @unSelectedPrompt="unSelectedPrompt"
                     @openSaveModal="openSaveModal"
                 />
             </div>
@@ -153,17 +153,6 @@ export default {
             // プロンプト一覧における個々の表示状態を設定
             setDisplayNsfw(displayNsfw.value)
             return commandList
-        }
-
-        // 画面読み込み時にマスタデータ一覧を取得、できなかった場合ローカルのjsファイルから取得
-        const getMasterData = async(): Promise<void> => {
-            const url = registerPath + 'api/getMasterData.php?from=spell_generator'
-            await axios.get(url)
-                .then(response => promptList.value = convertJsonToTagList(response.data))
-                .catch(error => {
-                    promptList.value = convertJsonToTagList(JSON.parse(master_data))
-                    console.log(error)
-                })
         }
 
         // 指定されたタグ名に該当するプロンプトを選択状態にする
@@ -329,7 +318,7 @@ export default {
         }
 
         // セットキューから指定したプロンプトを削除
-        const deleteSetPrompt = (promptListIndex: string): void => {
+        const unSelectedPrompt = (promptListIndex: string): void => {
             const tagsIndexList = promptListIndex.split(',')
             const i = parseInt(tagsIndexList[0])
             const j = parseInt(tagsIndexList[1])
@@ -348,6 +337,17 @@ export default {
         
         // モーダルの表示状態を更新する
         const updateModalState = (isDisplay: boolean): boolean => isOpenSaveModal.value = isDisplay
+
+        // 画面読み込み時にマスタデータ一覧を取得、できなかった場合ローカルのjsファイルから取得
+        const getMasterData = async(): Promise<void> => {
+            const url = registerPath + 'api/getMasterData.php?from=spell_generator'
+            await axios.get(url)
+                .then(response => promptList.value = convertJsonToTagList(response.data))
+                .catch(error => {
+                    promptList.value = convertJsonToTagList(JSON.parse(master_data))
+                    console.log(error)
+                })
+        }
 
         // ログインユーザーIDを取得
         const user_id = ref<string>('')
@@ -380,7 +380,7 @@ export default {
             toggleDisplayNsfw,
             addManualPrompt,
             updateSetPrompt,
-            deleteSetPrompt,
+            unSelectedPrompt,
             openSaveModal,
             updateModalState,
         }

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -205,6 +205,7 @@ export default {
                     if (setPrompt.value[index].tag === queue.tag) {
                         setPrompt.value.splice(index, 1)
                         promptList.value[i].content[j].selected = false
+                        return
                     }
                 }
             }

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -267,7 +267,7 @@ export default {
                 }
             }
             // リスト内のプロンプトと1つも合致しなかった場合、手動入力として扱う
-            addManualPrompt(promptName, enhanceCount)
+            addManualPrompt(uploadPromptName, enhanceCount)
             return
         }
 

--- a/src/SavedPrompt.vue
+++ b/src/SavedPrompt.vue
@@ -196,6 +196,7 @@ export default {
 
         // 画面ロード時、APIからログインユーザーの登録プロンプト一覧を取得
         onMounted(() => {
+            document.title = 'NovelAI プロンプトセーバー'
             getUserInfo()
             getPresetData()
         })

--- a/src/assets/scss/promptGenerator.scss
+++ b/src/assets/scss/promptGenerator.scss
@@ -1,14 +1,15 @@
 @import "./style.scss";
 
-.content {
+main.content {
     position: relative;
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: nowrap;
     margin: 0 8px;
-
+    
     @include mediaQuery(medium) {
-        > .main-content {
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: nowrap;
+        
+        > .prompt-list {
             width: calc(100% - 500px);
             border-right: 1px solid $border-color;
         }
@@ -81,7 +82,7 @@
     }
 }
 
-.tag-list {
+.prompt-list-area {
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
@@ -91,7 +92,7 @@
     }
 }
 
-.spell-list {
+.prompt-list-genre {
     width: 45%;
     padding: 0 6px 6px;
     margin: 26px 0 1em;
@@ -106,8 +107,11 @@
     @include mediaQuery(larger) {
         width: 17%;
     }
-
-    > .description {
+    
+    > div {
+        margin: 8px auto 0;
+    }
+    > div.description {
         display: flex;
         justify-content: space-between;
         > div {
@@ -128,8 +132,7 @@
     .caption {
         font-size: 14px;
     }
-    > div {
-        margin: 8px auto 0;
+    > div.prompt-list-prompt {
         overflow-y: auto;
     }
 }

--- a/src/assets/scss/promptGenerator.scss
+++ b/src/assets/scss/promptGenerator.scss
@@ -2,7 +2,6 @@
 
 main.content {
     position: relative;
-    margin: 0 8px;
     
     @include mediaQuery(medium) {
         display: flex;

--- a/src/assets/scss/promptGenerator.scss
+++ b/src/assets/scss/promptGenerator.scss
@@ -2,6 +2,7 @@
 
 main.content {
     position: relative;
+    margin: 0 8px;
     
     @include mediaQuery(medium) {
         display: flex;

--- a/src/components/HeaderComponent.vue
+++ b/src/components/HeaderComponent.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="header">
+    <header class="header">
         <h1><a href="https://novelai.net/image">NovelAI</a> プロンプトジェネレーター</h1>
         <div :class="[isOpenHBGMenu ? 'link-area open':'link-area' ]">
             <div class="main-link">
@@ -26,7 +26,7 @@
             <span class="bar"></span>
             <span class="bar"></span>
         </div>
-    </div>
+    </header>
 </template>
 <script lang="ts">
 import { computed, ref } from 'vue'

--- a/src/components/generator/ModalDBComponent.vue
+++ b/src/components/generator/ModalDBComponent.vue
@@ -65,7 +65,7 @@ import axios from 'axios'
 import '../../assets/scss/modalDB.scss'
 
 export default {
-    emits: ['updateModal', 'updateText'],
+    emits: ['updateModal',],
     props: {
         prompts: {
             type: String,
@@ -91,18 +91,17 @@ export default {
         })
         watchEffect(() => preset.value.commands = props.prompts)
 
-        const updateText = (text: string) => context.emit('updateText', text)
         const updateModal = (isDisplay: boolean) => context.emit('updateModal', isDisplay)
         
         // プリセットをDBに保存する
         const savePreset = () => {
             if (preset.value.commands === '') {
-                updateText('コマンドが入力されていません。')
+                alert('コマンドが入力されていません。')
                 updateModal(false)
                 return
             }
             if (preset.value.seed !== '' && isNaN(parseInt(preset.value.seed))) {
-                updateText('Seed値が数値で入力されていません。')
+                alert('Seed値が数値で入力されていません。')
                 updateModal(false)
                 return
             }
@@ -111,9 +110,9 @@ export default {
             const formData = JSON.stringify(preset.value)
             
             axios.post(formUrl, formData).then(() => {
-                updateText('プロンプトをデータベースに登録しました。')
+                alert('プロンプトをデータベースに登録しました。')
             }).catch(error => {
-                updateText('データベース接続に失敗しました。')
+                alert('データベース接続に失敗しました。')
                 console.log(error)
             })
 

--- a/src/components/generator/ModalDBComponent.vue
+++ b/src/components/generator/ModalDBComponent.vue
@@ -62,7 +62,7 @@
 import registerPath from '@/assets/ts/registerPath'
 import { ref, watchEffect } from 'vue'
 import axios from 'axios'
-import '../assets/scss/modalDB.scss'
+import '../../assets/scss/modalDB.scss'
 
 export default {
     emits: ['updateModal', 'updateText'],

--- a/src/components/generator/SetPromptComponent.vue
+++ b/src/components/generator/SetPromptComponent.vue
@@ -82,12 +82,8 @@ export default {
         draggable,
     },
     props: {
-        setPromptList: {
-            type: Object,
-        },
-        hoverPromptName: {
-            type:String
-        }
+        setPromptList: Object,
+        hoverPromptName: String,
     },
     emits: [
         'updateSetPrompt',
@@ -98,6 +94,7 @@ export default {
     setup(props: any, context: any) {
         const setPrompt = ref<{[key: string]: any}[]>([])
         watchEffect(() => setPrompt.value = props.setPromptList)
+        // カーソルを合わせているプロンプトの英語名
         const hoverPrompt = computed(() => props.hoverPromptName)
 
         // 親子間のプロンプト設定を同期させる
@@ -115,7 +112,6 @@ export default {
             if (setPrompt.value[index].index !== null) {
                 context.emit('unSelectedPrompt', setPrompt.value[index].index)
             }
-            
             setPrompt.value.splice(index, 1)
         }
 
@@ -135,6 +131,7 @@ export default {
 
         // 生成されたNovelAI形式のプロンプト
         const outputPrompt = ref('')
+        const enhanceBraceText = ref<string>('( )に変換')
         // キューにセットされているタグをNovelAIで使える形に変換する
         const convertToOutputPrompt = (spells: {[key: string]: any}[]): void => {
             const text = ref('')
@@ -153,12 +150,14 @@ export default {
                     text.value += '['.repeat(num) + spell.output_prompt + ']'.repeat(num)
                 }
                 text.value += ', '
-            })         
+            })
+            
+            // 強化値は{}に強制変更されるのでボタンの表示を変更
+            enhanceBraceText.value = '( )に変換'
             outputPrompt.value = text.value
         }
 
         // 強化値の()と{}を切り替える
-        const enhanceBraceText = ref<string>('( )に変換')
         const toggleEnhanceBrace = () => {
             if (enhanceBraceText.value === '( )に変換') {
                 enhanceBraceText.value = '{ }に変換'

--- a/src/components/generator/SetPromptComponent.vue
+++ b/src/components/generator/SetPromptComponent.vue
@@ -118,7 +118,10 @@ export default {
         // カラーバリエーションのあるプロンプトで色付きが選択された場合プロンプト名を変換
         const selectedColor = ref<{[key: string]: string}>({})
         const changePromptColor = (colorTag: {[key: string]: string}, index: number): void => {
+            // 一度表示名とタグ名をリセット
             const braceIndex = setPrompt.value[index].jp.indexOf('(')
+            setPrompt.value[index].output_prompt = setPrompt.value[index].tag
+
             if (braceIndex !== -1) {
                 setPrompt.value[index].jp = setPrompt.value[index].jp.substring(0, braceIndex-1)
             }

--- a/src/components/generator/SetPromptComponent.vue
+++ b/src/components/generator/SetPromptComponent.vue
@@ -92,7 +92,7 @@ export default {
     emits: [
         'updateSetPrompt',
         'addManualPrompt', 
-        'deleteSetPrompt', 
+        'unSelectedPrompt', 
         'openSaveModal'
     ],
     setup(props: any, context: any) {
@@ -113,7 +113,7 @@ export default {
         const deleteSetPrompt = (index: number) => {
             // プロンプト一覧から選択したプロンプトの場合親コンポーネントに伝えて選択を解除
             if (setPrompt.value[index].index !== null) {
-                context.emit('deleteSetPrompt', setPrompt.value[index].index)
+                context.emit('unSelectedPrompt', setPrompt.value[index].index)
             }
             
             setPrompt.value.splice(index, 1)

--- a/src/components/generator/SetPromptComponent.vue
+++ b/src/components/generator/SetPromptComponent.vue
@@ -97,11 +97,13 @@ export default {
     ],
     setup(props: any, context: any) {
         const setPrompt = ref<{[key: string]: any}[]>([])
-        watchEffect(() => setPrompt.value = props.setPromptList)
         const hoverPrompt = computed(() => props.hoverPromptName)
 
-        // プロンプト設定の内容が変更された場合、親コンポーネントのプロンプト設定も同時に更新する
-        watchEffect(() => context.emit('updateSetPrompt', setPrompt.value))
+        // 親子間のプロンプト設定を同期させる
+        watchEffect(() => {
+            setPrompt.value = props.setPromptList
+            context.emit('updateSetPrompt', setPrompt.value)
+        })
 
         // 手動入力でのプロンプトの追加
         const manualInput = ref<string>('')

--- a/src/components/generator/SetPromptComponent.vue
+++ b/src/components/generator/SetPromptComponent.vue
@@ -133,21 +133,21 @@ export default {
         const outputPrompt = ref('')
         const enhanceBraceText = ref<string>('( )に変換')
         // キューにセットされているタグをNovelAIで使える形に変換する
-        const convertToOutputPrompt = (spells: {[key: string]: any}[]): void => {
+        const convertToOutputPrompt = (setPrompt: {[key: string]: any}[]): void => {
             const text = ref('')
             
-            spells.map(spell => {
+            setPrompt.map(prompt => {
                 // タグの付与
                 // 強化値が0の場合そのまま追加
-                if (spell.enhance === 0) {
-                    text.value += spell.output_prompt
-                } else if (spell.enhance > 0) {
+                if (prompt.enhance === 0) {
+                    text.value += prompt.output_prompt
+                } else if (prompt.enhance > 0) {
                     // 強化値が1以上の場合前後に{}を数値分追加
-                    text.value += '{'.repeat(spell.enhance) + spell.output_prompt + '}'.repeat(spell.enhance) 
-                } else if (spell.enhance < 0) {
+                    text.value += '{'.repeat(prompt.enhance) + prompt.output_prompt + '}'.repeat(prompt.enhance) 
+                } else if (prompt.enhance < 0) {
                     // 強化値が-1以下の場合前後に[]を数値分追加
-                    const num = spell.enhance * -1
-                    text.value += '['.repeat(num) + spell.output_prompt + ']'.repeat(num)
+                    const num = prompt.enhance * -1
+                    text.value += '['.repeat(num) + prompt.output_prompt + ']'.repeat(num)
                 }
                 text.value += ', '
             })

--- a/src/components/generator/SetPromptComponent.vue
+++ b/src/components/generator/SetPromptComponent.vue
@@ -97,13 +97,11 @@ export default {
     ],
     setup(props: any, context: any) {
         const setPrompt = ref<{[key: string]: any}[]>([])
+        watchEffect(() => setPrompt.value = props.setPromptList)
         const hoverPrompt = computed(() => props.hoverPromptName)
 
         // 親子間のプロンプト設定を同期させる
-        watchEffect(() => {
-            setPrompt.value = props.setPromptList
-            context.emit('updateSetPrompt', setPrompt.value)
-        })
+        watchEffect(() => context.emit('updateSetPrompt', setPrompt.value))
 
         // 手動入力でのプロンプトの追加
         const manualInput = ref<string>('')

--- a/src/components/generator/SetPromptComponent.vue
+++ b/src/components/generator/SetPromptComponent.vue
@@ -1,0 +1,126 @@
+<template>
+    <div class="prompt-settings">
+        <div class="description">
+            <h2>設定プロンプト一覧</h2>
+            <small>選択中: {{hoverPrompt}}</small>
+            <div class="manual-input-area">
+                <label :for="'manual-input'">手動追加</label>
+                <input type="text" :id="'manual-input'" v-model="manualInput">
+                <button class="btn-common green" @click="addManualPrompt(manualInput)">追加</button>
+            </div>
+        </div>
+        <draggable 
+            class="prompt" 
+            v-model="setPrompt"
+            item-key="index"
+            handle=".prompt-variation-select"
+        >
+            <template #item="{element, index}">
+                <div class="draggable">
+                    <div class="prompt-variation-select">
+                        <div class="prompt-name">
+                            <div>
+                                <span class="caption">{{ element.parentTag }}</span>
+                                <p :class="['nsfw_' + element.nsfw]">{{ element.jp }}</p>
+                            </div>
+                        </div>
+                        <div v-if="element.color_list !== null">
+                            <span class="caption">色の設定</span>
+                            <select 
+                                :class="['nsfw_' + element.nsfw]"
+                                v-model="selectedColor" 
+                                @change="changePromptColor(selectedColor, index)"
+                            >
+                                <option disabled :value="{}">(選択)</option>
+                                <option v-for="color in element.color_list" :key="color.prompt" :value="color">{{ color.jp }}</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="enhance-area">
+                        <button @click="setPrompt[index].enhance -= 1" class="btn-common red">－</button>
+                        <span>{{ element.enhance }}</span>
+                        <button @click="setPrompt[index].enhance += 1" class="btn-common green">＋</button>
+                    </div>
+                    <div class="delete-area">
+                        <button @click="deleteSetPromptList(index)" class="btn-common red">削除</button>
+                    </div>
+                </div>
+            </template>
+        </draggable>
+        <div class="output-area">
+            <div class="text-area">
+                <p class="output"><b>出力値</b> (クリックで編集可)<br>
+                    <span v-if="!isEditNAIPrompt" @click="isEditNAIPrompt = true">
+                        {{ spellsNovelAI }}
+                    </span>
+                </p>
+                <textarea v-if="isEditNAIPrompt" v-model="spellsNovelAI" @keyup.enter="isEditNAIPrompt = false"></textarea>
+            </div>
+            <div class="button-area">
+                <div class="generate">
+                    <button @click="convertToNovelAITags(setPrompt)" class="btn-common green">呪文生成</button>
+                    <button @click="toggleEnhanceBrace()" :class="[enhanceBraceMessage === '( )に変換' ? 'btn-common blue':'btn-common green']">{{ enhanceBraceMessage }}</button>
+                </div>
+                <div class="save">
+                    <button @click="copyToClipboard(spellsNovelAI)" class="btn-common orange">コピー</button>
+                    <button 
+                        @click="openSaveModal(setPrompt, true)" class="btn-common blue open-save-modal"
+                    >保存</button>
+                </div>                
+            </div>
+            <span class="copy-alert">{{ copyAlert }}</span>           
+        </div>
+    </div>
+</template>
+<script lang="ts">
+import { colorMulti, colorMono } from './assets/ts/colorVariation'
+import { ref, onMounted } from 'vue'
+import draggable from 'vuedraggable'
+import './assets/scss/promptGenerator.scss'
+
+export default {
+    props: {
+        setSpells: {
+            type: Object,
+        },
+        hoverPromptName: {
+            type:String
+        }
+    },
+    emits: ['addManualPrompt', ],
+    setup(props: any, context: any) {
+        const setPrompt = ref<{[key: string]: any}[]>(props.setSpells)
+        const hoverPrompt = ref<string>(props.hoverPromptName)
+
+        // 手動入力でのプロンプトの追加
+        const manualInput = ref<string>('')
+        const addManualPrompt = (input: string, enhanceCount: number = 0): void => {
+            context.emit('addManualPrompt', input, enhanceCount)
+        }
+
+        // カラーバリエーションのあるプロンプトで色付きが選択された場合プロンプト名を変換
+        const selectedColor = ref<{[key: string]: string}>({})
+        const changePromptColor = (colorTag: {[key: string]: string}, index: number): void => {
+            const braceIndex = setPrompt.value[index].jp.indexOf('(')
+            if (braceIndex !== -1) {
+                setPrompt.value[index].jp = setPrompt.value[index].jp.substring(0, braceIndex-1)
+            }
+            if (colorTag.prompt !== 'none')  {
+                setPrompt.value[index].jp = setPrompt.value[index].jp + ' (' + colorTag.jp + ')'
+                setPrompt.value[index].output_prompt = colorTag.prompt + ' ' + setPrompt.value[index].tag
+            }
+            selectedColor.value = {}
+        }
+
+        return {
+            setPrompt,
+            hoverPrompt,
+            manualInput: manualInput,
+            selectedColor: selectedColor,
+
+            addManualPrompt,
+            changePromptColor,
+        }
+    } 
+}
+</script>

--- a/src/components/generator/SetPromptComponent.vue
+++ b/src/components/generator/SetPromptComponent.vue
@@ -50,11 +50,11 @@
         <div class="output-area">
             <div class="text-area">
                 <p class="output"><b>出力値</b> (クリックで編集可)<br>
-                    <span v-if="!isEditPrompt" @click="isEditPrompt = true">
+                    <span v-show="!isEditPrompt" @click="isEditPrompt = true">
                         {{ outputPrompt }}
                     </span>
                 </p>
-                <textarea v-if="isEditPrompt" v-model="outputPrompt" @keyup.enter="isEditPrompt = false"></textarea>
+                <textarea v-show="isEditPrompt" v-model="outputPrompt" @keyup.enter="isEditPrompt = false"></textarea>
             </div>
             <div class="button-area">
                 <div class="generate">


### PR DESCRIPTION
- プロンプト設定欄(画面右側)をcomponents/generator/SetPromptComponentに移動してコンポーネント化
- モーダルのComponentも同様のディレクトリに移動
- モーダルのDB登録時のメッセージをAlertにして不要Emits、Propsを消去
- PromptGenerator.vueのリファクタリング

150行以上減らして運用もしやすくなったよ！！やったね！！