### PR TITLE
vueファイルのscript setup構文対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@vue/cli-service": "~5.0.0",
         "@vue/eslint-config-typescript": "^9.1.0",
         "eslint": "^7.32.0",
-        "eslint-plugin-vue": "^8.0.3",
+        "eslint-plugin-vue": "^9.8.0",
         "node-sass": "^7.0.3",
         "sass-loader": "^13.1.0",
         "typescript": "~4.5.5"
@@ -5722,9 +5722,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmmirror.com/eslint-plugin-vue/-/eslint-plugin-vue-8.7.1.tgz",
-      "integrity": "sha512-28sbtm4l4cOzoO1LtzQPxfxhQABararUb1JtqusQqObJpWX2e/gmVyeYVfepizPFne0Q5cILkYGiBoV36L12Wg==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.8.0.tgz",
+      "integrity": "sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^3.0.0",
@@ -5732,13 +5732,27 @@
         "nth-check": "^2.0.1",
         "postcss-selector-parser": "^6.0.9",
         "semver": "^7.3.5",
-        "vue-eslint-parser": "^8.0.1"
+        "vue-eslint-parser": "^9.0.1",
+        "xml-name-validator": "^4.0.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^14.17.0 || >=16.0.0"
       },
       "peerDependencies": {
         "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vue/node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint-plugin-vue/node_modules/eslint-utils": {
@@ -5756,6 +5770,41 @@
         "eslint": ">=5"
       }
     },
+    "node_modules/eslint-plugin-vue/node_modules/espree": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-vue/node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vue/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/eslint-plugin-vue/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmmirror.com/semver/-/semver-7.3.8.tgz",
@@ -5769,6 +5818,39 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-vue/node_modules/vue-eslint-parser": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.1.0.tgz",
+      "integrity": "sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "eslint-scope": "^7.1.1",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.6"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vue/node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -13142,6 +13224,15 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz",
@@ -17845,9 +17936,9 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmmirror.com/eslint-plugin-vue/-/eslint-plugin-vue-8.7.1.tgz",
-      "integrity": "sha512-28sbtm4l4cOzoO1LtzQPxfxhQABararUb1JtqusQqObJpWX2e/gmVyeYVfepizPFne0Q5cILkYGiBoV36L12Wg==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.8.0.tgz",
+      "integrity": "sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",
@@ -17855,9 +17946,20 @@
         "nth-check": "^2.0.1",
         "postcss-selector-parser": "^6.0.9",
         "semver": "^7.3.5",
-        "vue-eslint-parser": "^8.0.1"
+        "vue-eslint-parser": "^9.0.1",
+        "xml-name-validator": "^4.0.0"
       },
       "dependencies": {
+        "eslint-scope": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
         "eslint-utils": {
           "version": "3.0.0",
           "resolved": "https://registry.npmmirror.com/eslint-utils/-/eslint-utils-3.0.0.tgz",
@@ -17867,6 +17969,31 @@
             "eslint-visitor-keys": "^2.0.0"
           }
         },
+        "espree": {
+          "version": "9.4.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+          "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.8.0",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^3.3.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+              "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+              "dev": true
+            }
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.8",
           "resolved": "https://registry.npmmirror.com/semver/-/semver-7.3.8.tgz",
@@ -17874,6 +18001,29 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "vue-eslint-parser": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.1.0.tgz",
+          "integrity": "sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.4",
+            "eslint-scope": "^7.1.1",
+            "eslint-visitor-keys": "^3.3.0",
+            "espree": "^9.3.1",
+            "esquery": "^1.4.0",
+            "lodash": "^4.17.21",
+            "semver": "^7.3.6"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+              "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+              "dev": true
+            }
           }
         }
       }
@@ -23481,6 +23631,12 @@
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "dev": true,
       "requires": {}
+    },
+    "xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@vue/cli-service": "~5.0.0",
     "@vue/eslint-config-typescript": "^9.1.0",
     "eslint": "^7.32.0",
-    "eslint-plugin-vue": "^8.0.3",
+    "eslint-plugin-vue": "^9.8.0",
     "node-sass": "^7.0.3",
     "sass-loader": "^13.1.0",
     "typescript": "~4.5.5"
@@ -36,7 +36,8 @@
   "eslintConfig": {
     "root": true,
     "env": {
-      "node": true
+      "node": true,
+      "vue/setup-compiler-macros": true
     },
     "extends": [
       "plugin:vue/vue3-essential",
@@ -46,7 +47,12 @@
     "parserOptions": {
       "parser": "@typescript-eslint/parser"
     },
-    "rules": {}
+    "rules": {
+        "no-unused-vars": "off",
+        "vue/no-unused-vars": "off",
+        "vue/script-setup-uses-vars": "off",
+        "@typescript-eslint/no-unused-vars": ["error"]
+    }
   },
   "browserslist": [
     "> 1%",

--- a/src/AccountManager.vue
+++ b/src/AccountManager.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import registerPath from '@/assets/ts/registerPath'
 import { AccountInfo } from '@/assets/ts/Interfaces/Index'
-import HeaderComponent from './HeaderComponent.vue'
-import '../assets/scss/manageAccount.scss'
+import HeaderComponent from '@/components/HeaderComponent.vue'
+import '@/assets/scss/manageAccount.scss'
 import axios from 'axios'
 import { ref, computed, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,3 @@
 <template>
     <router-view></router-view>
 </template>
-<script>
-export default {
-    
-}
-</script>
-<style lang="">
-    
-</style>

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -1,3 +1,288 @@
+<script setup lang="ts">
+import master_data from '@/assets/ts/master_data'
+import registerPath from '@/assets/ts/registerPath'
+import { Nsfw, Prompt, PromptList, SetPrompt } from '@/assets/ts/Interfaces/Index'
+import { colorMulti, colorMono } from './assets/ts/colorVariation'
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+import './assets/scss/promptGenerator.scss'
+import HeaderComponent from './components/HeaderComponent.vue'
+import SetPromptComponent from './components/generator/SetPromptComponent.vue'
+import ManagePresetComponent from './components/ManagePresetComponent.vue'
+
+// 表示するタグ一覧
+const promptList = ref<PromptList[]>([])
+// nsfwコンテンツの表示可否
+const displayNsfw = ref<Nsfw>('A')
+// Hover中のタグ
+const hoverPromptName = ref<string>('')
+// 手動入力内容
+const manualInput = ref<string>('')
+// セットされているタグ(プロンプト)のキュー
+const setPrompt = ref<SetPrompt[]>([])
+// アップロード用プロンプト
+const uploadPromptInput = ref<string>('')
+
+// 年齢制限表示に応じた個々のプロンプトの表示状態を設定する
+const judgeIsDisplay = (limit: string, promptNsfw: string): boolean => {
+    switch (limit) {
+        case 'A':
+            return promptNsfw === 'A' ? true:false
+        case 'C':
+            return promptNsfw === 'A' || promptNsfw === 'C' ? true:false          
+        case 'Z':
+            return true
+        default:
+            return promptNsfw === 'A' ? true:false
+    }
+}
+const setDisplayNsfw = (limit: string): void => {
+    promptList.value.map ((genre: PromptList, i: number) => {
+        promptList.value[i]['display'] = judgeIsDisplay(limit, promptList.value[i].nsfw)
+        genre.content.map((_: Prompt, j: number) => {
+            promptList.value[i].content[j]['display'] = judgeIsDisplay(limit, promptList.value[i].content[j].nsfw)
+        })
+    })
+} 
+
+// JSON文字列にしたマスタデータをJSオブジェクトの配列に変換
+const convertJsonToTagList = (jsonObj: PromptList[]): PromptList[] => {
+    const commandListQueue: PromptList[] = []
+    Object.keys(jsonObj).map((index: string) => commandListQueue.push(jsonObj[parseInt(index)]))
+
+    // 配列に表示に必要なデータを挿入
+    const commandList: PromptList[] = []
+    commandListQueue.map((genre: PromptList, i: number) => {
+        genre.show_all = false
+        genre.caption = genre.caption === "" ? "-" : genre.caption
+
+        genre.content.map((prompt: Prompt, j: number) => {  
+            prompt['slag'] = prompt.tag.replace(' ', '_')
+            prompt['selected'] = false
+            prompt['parentTag'] = genre.jp
+            prompt['index'] = i + ',' + j                    
+        })
+        commandList.push(genre)
+    })
+
+    return commandList
+}
+
+// 指定されたタグ名に該当するプロンプトを選択状態にする
+const selectPromptFromSearch = (word: string): void => {
+    promptList.value.map((genre: PromptList, i: number) => {
+        genre.content.map((prompt: Prompt, j: number) => {           
+            if (prompt.tag === word)  promptList.value[i].content[j].selected = true              
+        })
+    })
+}
+
+// 年齢制限切り替えボタンを押した際の処理
+const toggleDisplayNsfw = (limit: Nsfw): void => {
+    setPrompt.value.map(prompt => selectPromptFromSearch(prompt.tag))
+    displayNsfw.value = limit
+    setDisplayNsfw(displayNsfw.value)
+}
+
+// 手動入力でのプロンプトの追加
+const addManualPrompt = (input: string, enhanceCount: number = 0): void => {
+    let isAlreadySetPrompt = false
+    // 既に追加されているプロンプト名の場合追加しない
+    setPrompt.value.map((prompt: SetPrompt) => {
+        if (input.trim() === prompt.tag) isAlreadySetPrompt = true
+    })
+    if (!isAlreadySetPrompt && input.trim() !== '') {
+        setPrompt.value.push({
+            id: -1,
+            tag: input,
+            slag: input.replace(' ', '_'),
+            jp: input,
+            parentTag: '手動',
+            display: false,
+            selected: false,
+            nsfw: 'A',
+            variation: null,
+            index: null,
+            detail: '',
+            output_prompt: input,
+            enhance: enhanceCount,
+            color_list: null,
+        })
+    }
+}
+
+// タグのセットキューに挿入
+const toggleSetPromptList = (
+    i: number, 
+    j: number, 
+    enhanceCount: number = 0, 
+    colorTag: string = '',
+    colorTagJP: string = ''
+): void => { 
+    const queue: SetPrompt = {
+        ...promptList.value[i].content[j],
+        output_prompt: promptList.value[i].content[j].tag,
+        enhance: enhanceCount,
+        color_list: null,
+    }
+    
+    // プロンプト設定リストに存在するタグの場合、そのデータを消去し終了
+    const selected = promptList.value[i].content[j].selected
+    if (selected) {
+        for (let index = 0; index < setPrompt.value.length; index++) {
+            if (setPrompt.value[index].tag === queue.tag) {
+                setPrompt.value.splice(index, 1)
+                promptList.value[i].content[j].selected = false
+                return
+            }
+        }
+    }
+
+    // カラーバリエーション設定が存在する場合それに上書き
+    switch (promptList.value[i].content[j].variation) {
+        case 'CC':
+            queue['color_list'] = colorMulti
+            break
+        case 'CM':
+            queue['color_list'] = colorMono
+            break
+        default:
+            queue['color_list'] = null
+            break
+    }
+
+    // カラータグが存在する場合はタグ名と表示名を上書き
+    if (colorTag !== '' && colorTagJP !== '') {
+        queue.output_prompt = colorTag + ' ' + queue.tag
+        queue.jp = queue.jp + ' (' + colorTagJP + ')'
+    }
+
+    setPrompt.value.push(queue)
+    promptList.value[i].content[j].selected = true
+}
+
+// プロンプト一覧から指定されたプロンプト名を検索し、存在する場合プロンプト設定欄にデータを挿入
+const searchPrompt = (uploadPromptName: string, enhanceCount: number): void => {            
+    // アップロードされたプロンプトにスペースが存在するか調べる
+    const spaceIndex = uploadPromptName.indexOf(' ')
+    const colorTag = uploadPromptName.substring(0, spaceIndex)
+    const colorTagJP = ref<string>('')
+    
+    // スペースが存在する場合スペース以前の単語がカラータグかどうか調べる
+    if (colorTag !== '') {
+        colorMulti.map(color => {
+            if (colorTag === color.prompt) colorTagJP.value = color.jp
+        })
+    } 
+    // 検索するプロンプト名。カラータグが付いていた場合最初のスペース以後、それ以外の場合引数の値。
+    const promptName = colorTagJP.value === '' ? uploadPromptName : uploadPromptName.substring(spaceIndex + 1)
+    
+    for (let i = 0; i < promptList.value.length; i++) {
+        for (let j = 0; j < promptList.value[i].content.length; j++) {
+            
+            const prompt = promptList.value[i].content[j]
+            // アップロードされたプロンプト名とリスト内のプロンプトが一致した場合、プロンプト設定のリストにそのプロンプトのデータを挿入
+            if (prompt.tag === promptName) {
+                toggleSetPromptList(i, j, enhanceCount, colorTag, colorTagJP.value)
+                // nsfw設定をプロンプトのnsfw設定に上書き
+                if (displayNsfw.value === 'A' || (displayNsfw.value === 'C' && prompt.nsfw === 'Z')) {
+                    displayNsfw.value = prompt.nsfw
+                } 
+                setDisplayNsfw(displayNsfw.value)
+                return
+            }
+        }
+    }
+    // リスト内のプロンプトと1つも合致しなかった場合、手動入力として扱う
+    addManualPrompt(uploadPromptName, enhanceCount)
+    return
+}
+
+// 既存のタグがアップロードされた場合、セットキューに対象値を追加
+const uploadPrompt = (inputPromptList: string): void => {
+    if (inputPromptList.trim() === '') return
+    // 既存の設定プロンプトリストと手動入力欄をリセット
+    setPrompt.value = []
+    manualInput.value = ''
+    promptList.value.map((genre: PromptList, i: number) => {
+        genre.content.map((_: Prompt, j: number) => {
+            promptList.value[i].content[j].selected = false
+        })
+    })
+
+    // タグごと配列の要素にする
+    const uploadedPromptList = inputPromptList.split(',').map(tag => tag.trim())
+    uploadedPromptList.map((prompt: string, index: number) => {
+        if(prompt.trim() === "") {
+            uploadedPromptList.splice(index, 1)
+        } else {
+            // 文字の前後に{}または[]がある場合、その数分強化値を追加する
+            const enhanceCount = ref(0)
+            if (prompt.match(/\{/g) !== null) {
+                enhanceCount.value = prompt.match(/\{/g)!.length
+            } else if (prompt.match(/\[/g) !== null) {
+                enhanceCount.value = prompt.match(/\[/g)!.length * -1 
+            } else if (prompt.match(/\(/g) !== null) {
+                enhanceCount.value = prompt.match(/\(/g)!.length
+            } 
+            const promptName = prompt.replace(/\{/g, "").replace(/\}/g, "").replace(/\[/g, "").replace(/\]/g, "").replace(/\(/g, "").replace(/\)/g, "")
+
+            // プロンプト一覧から指定したプロンプトを検索
+            searchPrompt(promptName, enhanceCount.value)      
+        }
+    })
+}
+
+// 子コンポーネントから伝えられたプロンプト設定欄の内容を更新
+const updateSetPrompt = (childSetPrompt: SetPrompt[]) => setPrompt.value = childSetPrompt
+
+// セットキューから指定したプロンプトを削除
+const unSelectedPrompt = (promptListIndex: string): void => {
+    const tagsIndexList = promptListIndex.split(',')
+    const i = parseInt(tagsIndexList[0])
+    const j = parseInt(tagsIndexList[1])
+    
+    promptList.value[i].content[j].selected = false
+}
+
+// DB保存モーダルの表示可否
+const isOpenSaveModal = ref<boolean>(false)
+// モーダルの表示状態を更新する
+const updateModalState = (isDisplay: boolean): boolean => isOpenSaveModal.value = isDisplay
+
+const outputPrompt = ref<string>('')
+// DB保存用のモーダルを開く
+const openSaveModal = (modalState: boolean, output: string): void => {
+    outputPrompt.value = output
+    updateModalState(modalState)
+}
+
+// DBからマスタデータ一覧を取得、できなかった場合ローカルのjsファイルから取得
+const getMasterData = async(): Promise<void> => {
+    const url = registerPath + 'api/getMasterData.php?from=spell_generator'
+    await axios.get(url)
+        .then(response => { 
+            promptList.value = convertJsonToTagList(response.data)
+            setDisplayNsfw(displayNsfw.value)
+        })
+        .catch(error => {
+            promptList.value = convertJsonToTagList(JSON.parse(master_data))
+            setDisplayNsfw(displayNsfw.value)
+            console.log(error)
+        })
+}
+
+// ログインユーザーIDを取得
+const user_id = ref<string>('')
+const getUserInfo = (userId: string) => user_id.value = userId; 
+
+// 画面読み込み時、ログインユーザーIDを取得し、DBからマスタデータを取得。できない場合はローカルから取得。
+onMounted(() => {
+    document.title = 'NovelAI プロンプトジェネレーター'
+    getMasterData()
+})
+</script>
+
 <template>
     <HeaderComponent @getUserInfo="getUserInfo"></HeaderComponent>
     <main class="prompt-generator">
@@ -70,321 +355,3 @@
     />
     <router-view></router-view>
 </template>
-
-<script lang="ts">
-import master_data from '@/assets/ts/master_data'
-import registerPath from '@/assets/ts/registerPath'
-import { Nsfw, ColorVariation, Prompt, PromptList, SetPrompt } from '@/assets/ts/Interfaces/Index'
-import { colorMulti, colorMono } from './assets/ts/colorVariation'
-import { ref, onMounted } from 'vue'
-import axios from 'axios'
-import './assets/scss/promptGenerator.scss'
-import HeaderComponent from './components/HeaderComponent.vue'
-import SetPromptComponent from './components/generator/SetPromptComponent.vue'
-import ManagePresetComponent from './components/ManagePresetComponent.vue'
-
-export default {
-    components: {
-        HeaderComponent,
-        SetPromptComponent,
-        ManagePresetComponent,
-    },
-    setup() {
-
-        // 表示するタグ一覧
-        const promptList = ref<PromptList[]>([])
-        // nsfwコンテンツの表示可否
-        const displayNsfw = ref<Nsfw>('A')
-        // Hover中のタグ
-        const hoverPromptName = ref<string>('')
-        // アップロード用プロンプト
-        const uploadPromptInput = ref<string>('')
-        // 手動入力内容
-        const manualInput = ref<string>('')
-        // セットされているタグ(プロンプト)のキュー
-        const setPrompt = ref<SetPrompt[]>([])
-        // カラー設定可能なプロンプトの選択されたカラーを格納する配列
-        const selectedColor = ref<ColorVariation>({prompt: '', jp: ''})
-
-        // 年齢制限表示に応じた個々のプロンプトの表示状態を設定する
-        const judgeIsDisplay = (limit: string, promptNsfw: string): boolean => {
-            switch (limit) {
-                case 'A':
-                    return promptNsfw === 'A' ? true:false
-                case 'C':
-                    return promptNsfw === 'A' || promptNsfw === 'C' ? true:false          
-                case 'Z':
-                    return true
-                default:
-                    return promptNsfw === 'A' ? true:false
-            }
-        }
-        const setDisplayNsfw = (limit: string): void => {
-            promptList.value.map ((genre: PromptList, i: number) => {
-                promptList.value[i]['display'] = judgeIsDisplay(limit, promptList.value[i].nsfw)
-                genre.content.map((_: Prompt, j: number) => {
-                    promptList.value[i].content[j]['display'] = judgeIsDisplay(limit, promptList.value[i].content[j].nsfw)
-                })
-            })
-        } 
-
-        // JSON文字列にしたマスタデータをJSオブジェクトの配列に変換
-        const convertJsonToTagList = (jsonObj: PromptList[]): PromptList[] => {
-            const commandListQueue: PromptList[] = []
-            Object.keys(jsonObj).map((index: string) => commandListQueue.push(jsonObj[parseInt(index)]))
-
-            // 配列に表示に必要なデータを挿入
-            const commandList: PromptList[] = []
-            commandListQueue.map((genre: PromptList, i: number) => {
-                genre.show_all = false
-                genre.caption = genre.caption === "" ? "-" : genre.caption
-
-                genre.content.map((prompt: Prompt, j: number) => {  
-                    prompt['slag'] = prompt.tag.replace(' ', '_')
-                    prompt['selected'] = false
-                    prompt['parentTag'] = genre.jp
-                    prompt['index'] = i + ',' + j                    
-                })
-                commandList.push(genre)
-            })
-
-            return commandList
-        }
-
-        // 指定されたタグ名に該当するプロンプトを選択状態にする
-        const selectPromptFromSearch = (word: string): void => {
-            promptList.value.map((genre: PromptList, i: number) => {
-                genre.content.map((prompt: Prompt, j: number) => {           
-                    if (prompt.tag === word)  promptList.value[i].content[j].selected = true              
-                })
-            })
-        }
-        
-        // 年齢制限切り替えボタンを押した際の処理
-        const toggleDisplayNsfw = (limit: Nsfw): void => {
-            setPrompt.value.map(prompt => selectPromptFromSearch(prompt.tag))
-            displayNsfw.value = limit
-            setDisplayNsfw(displayNsfw.value)
-        }
-
-        // 手動入力でのプロンプトの追加
-        const addManualPrompt = (input: string, enhanceCount: number = 0): void => {
-            let isAlreadySetPrompt = false
-            // 既に追加されているプロンプト名の場合追加しない
-            setPrompt.value.map((prompt: SetPrompt) => {
-                if (input.trim() === prompt.tag) isAlreadySetPrompt = true
-            })
-            if (!isAlreadySetPrompt && input.trim() !== '') {
-                setPrompt.value.push({
-                    id: -1,
-                    tag: input,
-                    slag: input.replace(' ', '_'),
-                    jp: input,
-                    parentTag: '手動',
-                    display: false,
-                    selected: false,
-                    nsfw: 'A',
-                    variation: null,
-                    index: null,
-                    detail: '',
-                    output_prompt: input,
-                    enhance: enhanceCount,
-                    color_list: null,
-                })
-            }
-        }
-
-        // タグのセットキューに挿入
-        const toggleSetPromptList = (
-            i: number, 
-            j: number, 
-            enhanceCount: number = 0, 
-            colorTag: string = '',
-            colorTagJP: string = ''
-        ): void => { 
-            const queue: SetPrompt = {
-                ...promptList.value[i].content[j],
-                output_prompt: promptList.value[i].content[j].tag,
-                enhance: enhanceCount,
-                color_list: null,
-            }
-            
-            // プロンプト設定リストに存在するタグの場合、そのデータを消去し終了
-            const selected = promptList.value[i].content[j].selected
-            if (selected) {
-                for (let index = 0; index < setPrompt.value.length; index++) {
-                    if (setPrompt.value[index].tag === queue.tag) {
-                        setPrompt.value.splice(index, 1)
-                        promptList.value[i].content[j].selected = false
-                        return
-                    }
-                }
-            }
-
-            // カラーバリエーション設定が存在する場合それに上書き
-            switch (promptList.value[i].content[j].variation) {
-                case 'CC':
-                    queue['color_list'] = colorMulti
-                    break
-                case 'CM':
-                    queue['color_list'] = colorMono
-                    break
-                default:
-                    queue['color_list'] = null
-                    break
-            }
-
-            // カラータグが存在する場合はタグ名と表示名を上書き
-            if (colorTag !== '' && colorTagJP !== '') {
-                queue.output_prompt = colorTag + ' ' + queue.tag
-                queue.jp = queue.jp + ' (' + colorTagJP + ')'
-            }
-
-            setPrompt.value.push(queue)
-            promptList.value[i].content[j].selected = true
-        }
-
-        // プロンプト一覧から指定されたプロンプト名を検索し、存在する場合プロンプト設定欄にデータを挿入
-        const searchPrompt = (uploadPromptName: string, enhanceCount: number): void => {            
-            // アップロードされたプロンプトにスペースが存在するか調べる
-            const spaceIndex = uploadPromptName.indexOf(' ')
-            const colorTag = uploadPromptName.substring(0, spaceIndex)
-            const colorTagJP = ref<string>('')
-            
-            // スペースが存在する場合スペース以前の単語がカラータグかどうか調べる
-            if (colorTag !== '') {
-                colorMulti.map(color => {
-                    if (colorTag === color.prompt) colorTagJP.value = color.jp
-                })
-            } 
-            // 検索するプロンプト名。カラータグが付いていた場合最初のスペース以後、それ以外の場合引数の値。
-            const promptName = colorTagJP.value === '' ? uploadPromptName : uploadPromptName.substring(spaceIndex + 1)
-            
-            for (let i = 0; i < promptList.value.length; i++) {
-                for (let j = 0; j < promptList.value[i].content.length; j++) {
-                    
-                    const prompt = promptList.value[i].content[j]
-                    // アップロードされたプロンプト名とリスト内のプロンプトが一致した場合、プロンプト設定のリストにそのプロンプトのデータを挿入
-                    if (prompt.tag === promptName) {
-                        toggleSetPromptList(i, j, enhanceCount, colorTag, colorTagJP.value)
-                        // nsfw設定をプロンプトのnsfw設定に上書き
-                        if (displayNsfw.value === 'A' || (displayNsfw.value === 'C' && prompt.nsfw === 'Z')) {
-                            displayNsfw.value = prompt.nsfw
-                        } 
-                        setDisplayNsfw(displayNsfw.value)
-                        return
-                    }
-                }
-            }
-            // リスト内のプロンプトと1つも合致しなかった場合、手動入力として扱う
-            addManualPrompt(uploadPromptName, enhanceCount)
-            return
-        }
-
-        // 既存のタグがアップロードされた場合、セットキューに対象値を追加
-        const uploadPrompt = (inputPromptList: string): void => {
-            if (inputPromptList.trim() === '') return
-            // 既存の設定プロンプトリストと手動入力欄をリセット
-            setPrompt.value = []
-            manualInput.value = ''
-            promptList.value.map((genre: PromptList, i: number) => {
-                genre.content.map((_: Prompt, j: number) => {
-                    promptList.value[i].content[j].selected = false
-                })
-            })
-
-            // タグごと配列の要素にする
-            const uploadedPromptList = inputPromptList.split(',').map(tag => tag.trim())
-            uploadedPromptList.map((prompt: string, index: number) => {
-                if(prompt.trim() === "") {
-                    uploadedPromptList.splice(index, 1)
-                } else {
-                    // 文字の前後に{}または[]がある場合、その数分強化値を追加する
-                    const enhanceCount = ref(0)
-                    if (prompt.match(/\{/g) !== null) {
-                        enhanceCount.value = prompt.match(/\{/g)!.length
-                    } else if (prompt.match(/\[/g) !== null) {
-                        enhanceCount.value = prompt.match(/\[/g)!.length * -1 
-                    } else if (prompt.match(/\(/g) !== null) {
-                        enhanceCount.value = prompt.match(/\(/g)!.length
-                    } 
-                    const promptName = prompt.replace(/\{/g, "").replace(/\}/g, "").replace(/\[/g, "").replace(/\]/g, "").replace(/\(/g, "").replace(/\)/g, "")
-
-                    // プロンプト一覧から指定したプロンプトを検索
-                    searchPrompt(promptName, enhanceCount.value)      
-                }
-            })
-        }
-
-        // 子コンポーネントから伝えられたプロンプト設定欄の内容を更新
-        const updateSetPrompt = (childSetPrompt: SetPrompt[]) => setPrompt.value = childSetPrompt
-        
-        // セットキューから指定したプロンプトを削除
-        const unSelectedPrompt = (promptListIndex: string): void => {
-            const tagsIndexList = promptListIndex.split(',')
-            const i = parseInt(tagsIndexList[0])
-            const j = parseInt(tagsIndexList[1])
-            
-            promptList.value[i].content[j].selected = false
-        }
-
-        // DB保存モーダルの表示可否
-        const isOpenSaveModal = ref<boolean>(false)
-        // モーダルの表示状態を更新する
-        const updateModalState = (isDisplay: boolean): boolean => isOpenSaveModal.value = isDisplay
-
-        const outputPrompt = ref<string>('')
-        // DB保存用のモーダルを開く
-        const openSaveModal = (modalState: boolean, output: string): void => {
-            outputPrompt.value = output
-            updateModalState(modalState)
-        }
-        
-        // DBからマスタデータ一覧を取得、できなかった場合ローカルのjsファイルから取得
-        const getMasterData = async(): Promise<void> => {
-            const url = registerPath + 'api/getMasterData.php?from=spell_generator'
-            await axios.get(url)
-                .then(response => { 
-                    promptList.value = convertJsonToTagList(response.data)
-                    setDisplayNsfw(displayNsfw.value)
-                })
-                .catch(error => {
-                    promptList.value = convertJsonToTagList(JSON.parse(master_data))
-                    setDisplayNsfw(displayNsfw.value)
-                    console.log(error)
-                })
-        }
-
-        // ログインユーザーIDを取得
-        const user_id = ref<string>('')
-        const getUserInfo = (userId: string) => user_id.value = userId; 
-
-        // 画面読み込み時、ログインユーザーIDを取得し、DBからマスタデータを取得。できない場合はローカルから取得。
-        onMounted(() => {
-            document.title = 'NovelAI プロンプトジェネレーター'
-            getMasterData()
-        })
-        
-        return {
-            promptList,
-            hoverPromptName,
-            setPrompt,
-            isOpenSaveModal,
-            displayNsfw: displayNsfw,
-            manualInput: manualInput,
-            uploadPromptInput: uploadPromptInput,
-            selectedColor: selectedColor,
-            outputPrompt: outputPrompt,
-            uploadPrompt,
-            toggleSetPromptList,
-            toggleDisplayNsfw,
-            addManualPrompt,
-            updateSetPrompt,
-            unSelectedPrompt,
-            openSaveModal,
-            updateModalState,
-            getUserInfo,
-        }
-    }
-}
-</script>

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -353,8 +353,7 @@ onMounted(() => {
     <ManagePresetComponent
         id="generator"
         :prompts="outputPrompt"
-        :displayModalState="isOpenSaveModal"
-        @updateModal="updateModalState"
+        @updateModalState="updateModalState"
         :style="[isOpenSaveModal ? 'display: block' : 'display: none']"
     />
     <router-view></router-view>

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -237,7 +237,11 @@ const uploadPrompt = (inputPromptList: string): void => {
 const updateSetPrompt = (childSetPrompt: SetPrompt[]) => setPrompt.value = childSetPrompt
 
 // セットキューから指定したプロンプトを削除
-const unSelectedPrompt = (promptListIndex: string): void => {
+const unSelectedPrompt = (promptListIndex: string | null): void => {
+    // 送られてきた値がnullの場合プロンプト一覧には存在しないので何もせず終了
+    if (promptListIndex === null) return
+
+    // プロンプト一覧から指定されたインデックスのプロンプトの選択を解除
     const tagsIndexList = promptListIndex.split(',')
     const i = parseInt(tagsIndexList[0])
     const j = parseInt(tagsIndexList[1])

--- a/src/PromptGenerator.vue
+++ b/src/PromptGenerator.vue
@@ -2,13 +2,13 @@
 import master_data from '@/assets/ts/master_data'
 import registerPath from '@/assets/ts/registerPath'
 import { Nsfw, Prompt, PromptList, SetPrompt } from '@/assets/ts/Interfaces/Index'
-import { colorMulti, colorMono } from './assets/ts/colorVariation'
+import { colorMulti, colorMono } from '@/assets/ts/colorVariation'
 import { ref, onMounted } from 'vue'
 import axios from 'axios'
-import './assets/scss/promptGenerator.scss'
-import HeaderComponent from './components/HeaderComponent.vue'
-import SetPromptComponent from './components/generator/SetPromptComponent.vue'
-import ManagePresetComponent from './components/ManagePresetComponent.vue'
+import '@/assets/scss/promptGenerator.scss'
+import HeaderComponent from '@/components/HeaderComponent.vue'
+import SetPromptComponent from '@/components/generator/SetPromptComponent.vue'
+import ManagePresetComponent from '@/components/ManagePresetComponent.vue'
 
 // 表示するタグ一覧
 const promptList = ref<PromptList[]>([])

--- a/src/SavedPrompt.vue
+++ b/src/SavedPrompt.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import registerPath from '@/assets/ts/registerPath'
-import HeaderComponent from './components/HeaderComponent.vue'
-import SearchBoxComponent from './components/saver/SearchBoxComponent.vue'
-import SelectedPresetComponent from './components/saver/SelectedPresetComponent.vue'
-import ManagePresetComponent from './components/ManagePresetComponent.vue'
+import HeaderComponent from '@/components/HeaderComponent.vue'
+import SearchBoxComponent from '@/components/saver/SearchBoxComponent.vue'
+import SelectedPresetComponent from '@/components/saver/SelectedPresetComponent.vue'
+import ManagePresetComponent from '@/components/ManagePresetComponent.vue'
 import { Preset, PresetDetail, SearchData } from '@/assets/ts/Interfaces/Index'
-import './assets/scss/savedPrompt.scss'
+import '@/assets/scss/savedPrompt.scss'
 import { ref, onMounted } from 'vue'
 import axios from 'axios'
 

--- a/src/SavedPrompt.vue
+++ b/src/SavedPrompt.vue
@@ -1,3 +1,162 @@
+<script setup lang="ts">
+import registerPath from '@/assets/ts/registerPath'
+import HeaderComponent from './components/HeaderComponent.vue'
+import SearchBoxComponent from './components/saver/SearchBoxComponent.vue'
+import SelectedPresetComponent from './components/saver/SelectedPresetComponent.vue'
+import ManagePresetComponent from './components/ManagePresetComponent.vue'
+import { Preset, PresetDetail, SearchData } from '@/assets/ts/Interfaces/Index'
+import './assets/scss/savedPrompt.scss'
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+
+// ログインユーザーの登録プリセット一覧
+const savedPromptList = ref<PresetDetail[]>([])
+// 検索ボックスの表示有無
+const isDisplaySearchBox = ref<boolean>(false)
+
+// DBで文字列で保管されているオプションと解像度を表示できるように変更
+const revertDBData = (presets: Preset[]) => {
+    presets.map((preset, index) => {
+        if (preset.options !== null && preset.options !== '') {
+            savedPromptList.value[index].options = preset.options.split(',')
+        } else {
+            savedPromptList.value[index].options = []
+        }
+
+        if (preset.resolution !== null && preset.resolution !== '') {
+            const resolutionList = preset.resolution.split('x')
+            savedPromptList.value[index]['resolution_width'] = resolutionList[0]
+            savedPromptList.value[index]['resolution_height'] = resolutionList[1]
+        }
+    })
+}
+
+// 各プリセットに対応する画像とサムネイルのURLを取得
+const setImages = (presets: Preset[]) => {
+    const imgPath = registerPath + 'images/preset/'
+    presets.map((preset, index) => {
+        savedPromptList.value[index]['thumbnail'] = preset.image === null ?
+            imgPath + 'noimage.png' : 
+            imgPath + 'thumbnail/' + preset.image
+        savedPromptList.value[index]['imagePath'] = preset.image === null ?
+            imgPath + 'noimage.png' : 
+            imgPath + 'original/' + preset.image
+    })
+}
+
+// 各プリセットがnsfwかどうか判定
+const setIsNsfw = (presets: Preset[]) => {
+    presets.map((_, index) => {
+        switch (savedPromptList.value[index].nsfw) {
+            case 'A':
+                savedPromptList.value[index]['nsfw_display'] = '全年齢'
+                break
+            case 'C':
+                savedPromptList.value[index]['nsfw_display'] = 'R-15'
+                break
+            case 'Z':
+                savedPromptList.value[index]['nsfw_display'] = 'R-18'
+                break
+        }
+    })
+}
+
+// プリセット一覧から選択されたプリセットを読み込む
+const presetInitialData: PresetDetail = {
+    index: 0,
+    thumbnail: '',
+    nsfw_display: '全年齢',
+    preset_id: -1,
+    image: '',
+    imagePath: '',
+    from: 'generator',
+    commands: '',
+    commands_ban: '',
+    description: '',
+    nsfw: 'A',
+    seed: '',
+    resolution_width: 512,
+    resolution_height: 768,
+    resolution: '',
+    model: 'NovelAI',
+    sampling: 28,
+    sampling_algo: 'Euler a',
+    scale: 11,
+    options: ['Highres. Fix'],
+    others: '',
+}
+// 選択されたプリセットデータ
+const selectedPreset = ref<PresetDetail>(presetInitialData)
+const selectedPresetIndex = ref<number>(-1)
+const selectPreset = (selectPresetIndex: number) => {
+    if (selectPresetIndex === -1) {
+        selectedPreset.value = {...presetInitialData}
+        selectedPreset.value.index = savedPromptList.value.length
+    } else {
+        selectedPreset.value = {...savedPromptList.value[selectPresetIndex]}
+        selectedPreset.value.index = selectPresetIndex
+    }
+    selectedPresetIndex.value = selectPresetIndex
+}
+
+// データ登録・編集モードの状態
+const isRegisterMode = ref<boolean>(true)
+const setRegisterMode = (state: boolean, mode: string = '') => {
+    // 新規登録の場合は選択されているプリセット詳細データを初期化
+    if (state && mode === 'register') selectPreset(-1)
+    isRegisterMode.value = state
+}
+
+// 検索ボックスの入力内容
+const searchData = ref<SearchData>({
+    method: 'search',
+    age: ['A'],
+    item: ['description', 'commands'],
+    word: '',
+    sort: 'created_at',
+    order: 'asc'
+})
+
+// プリセット検索APIを呼び出し、検索ボックスの内容に応じた値を取得
+const getPresetData = async(postData: SearchData = searchData.value) => {
+    const url = registerPath +  'api/managePreset.php'
+    // プリセットを初期化
+    savedPromptList.value = []
+    await axios.get(url, {
+        params: postData
+    }).then(response => {
+            if (response.data !== '') {
+                savedPromptList.value = response.data
+                revertDBData(savedPromptList.value)
+                setImages(savedPromptList.value)
+                setIsNsfw(savedPromptList.value)
+            }
+        })
+        .catch(error => {
+            console.log(error) 
+        })
+}
+
+// コピーした際のアラートを設定
+const alertText = ref<string>('') 
+const setAlertText = (text: string) => alertText.value = text
+
+// ページ遷移用のURI
+// テストサーバーも含める為パス名を取得して結合
+const originPath = new URL(location.href).origin + location.pathname
+
+// ログインユーザーIDを取得
+const user_id = ref<string>('')
+const getUserInfo = (userId: string) => user_id.value = userId
+
+
+// 画面ロード時、APIからログインユーザーの登録プロンプト一覧を取得
+onMounted(() => {
+    document.title = 'NovelAI プロンプトセーバー'
+    getPresetData()
+})
+</script>
+
 <template>
     <HeaderComponent @getUserInfo="getUserInfo" />
     <main class="saved-prompt">
@@ -71,190 +230,3 @@
         </div>
     </main>
 </template>
-<script lang="ts">
-import registerPath from '@/assets/ts/registerPath'
-import HeaderComponent from './components/HeaderComponent.vue'
-import SearchBoxComponent from './components/saver/SearchBoxComponent.vue'
-import SelectedPresetComponent from './components/saver/SelectedPresetComponent.vue'
-import ManagePresetComponent from './components/ManagePresetComponent.vue'
-import { Preset, PresetDetail, SearchData } from '@/assets/ts/Interfaces/Index'
-import './assets/scss/savedPrompt.scss'
-import { ref, onMounted } from 'vue'
-import axios from 'axios'
-
-export default {
-    components: {
-        HeaderComponent,
-        SearchBoxComponent,
-        SelectedPresetComponent,
-        ManagePresetComponent,
-    },
-    setup() {
-        // ログインユーザーの登録プリセット一覧
-        const savedPromptList = ref<PresetDetail[]>([])
-        
-        // 検索ボックスの表示有無
-        const isDisplaySearchBox = ref<boolean>(false)
-
-        // DBで文字列で保管されているオプションと解像度を表示できるように変更
-        const revertDBData = (presets: Preset[]) => {
-            presets.map((preset, index) => {
-                if (preset.options !== null && preset.options !== '') {
-                    savedPromptList.value[index].options = preset.options.split(',')
-                } else {
-                    savedPromptList.value[index].options = []
-                }
-
-                if (preset.resolution !== null && preset.resolution !== '') {
-                    const resolutionList = preset.resolution.split('x')
-                    savedPromptList.value[index]['resolution_width'] = resolutionList[0]
-                    savedPromptList.value[index]['resolution_height'] = resolutionList[1]
-                }
-            })
-        }
-        
-        // 各プリセットに対応する画像とサムネイルのURLを取得
-        const setImages = (presets: Preset[]) => {
-            const imgPath = registerPath + 'images/preset/'
-            presets.map((preset, index) => {
-                savedPromptList.value[index]['thumbnail'] = preset.image === null ?
-                    imgPath + 'noimage.png' : 
-                    imgPath + 'thumbnail/' + preset.image
-                savedPromptList.value[index]['imagePath'] = preset.image === null ?
-                    imgPath + 'noimage.png' : 
-                    imgPath + 'original/' + preset.image
-            })
-        }
-
-        // 各プリセットがnsfwかどうか判定
-        const setIsNsfw = (presets: Preset[]) => {
-            presets.map((_, index) => {
-                switch (savedPromptList.value[index].nsfw) {
-                    case 'A':
-                        savedPromptList.value[index]['nsfw_display'] = '全年齢'
-                        break
-                    case 'C':
-                        savedPromptList.value[index]['nsfw_display'] = 'R-15'
-                        break
-                    case 'Z':
-                        savedPromptList.value[index]['nsfw_display'] = 'R-18'
-                        break
-                }
-            })
-        }
-        
-        // プリセット一覧から選択されたプリセットを読み込む
-        const presetInitialData: PresetDetail = {
-            index: 0,
-            thumbnail: '',
-            nsfw_display: '全年齢',
-            preset_id: -1,
-            image: '',
-            imagePath: '',
-            from: 'generator',
-            commands: '',
-            commands_ban: '',
-            description: '',
-            nsfw: 'A',
-            seed: '',
-            resolution_width: 512,
-            resolution_height: 768,
-            resolution: '',
-            model: 'NovelAI',
-            sampling: 28,
-            sampling_algo: 'Euler a',
-            scale: 11,
-            options: ['Highres. Fix'],
-            others: '',
-        }
-        // 選択されたプリセットデータ
-        const selectedPreset = ref<PresetDetail>(presetInitialData)
-        const selectedPresetIndex = ref<number>(-1)
-        const selectPreset = (selectPresetIndex: number) => {
-            if (selectPresetIndex === -1) {
-                selectedPreset.value = {...presetInitialData}
-                selectedPreset.value.index = savedPromptList.value.length
-            } else {
-                selectedPreset.value = {...savedPromptList.value[selectPresetIndex]}
-                selectedPreset.value.index = selectPresetIndex
-            }
-            selectedPresetIndex.value = selectPresetIndex
-        }
-
-        // データ登録・編集モードの状態
-        const isRegisterMode = ref<boolean>(true)
-        const setRegisterMode = (state: boolean, mode: string = '') => {
-            // 新規登録の場合は選択されているプリセット詳細データを初期化
-            if (state && mode === 'register') selectPreset(-1)
-            isRegisterMode.value = state
-        }
-
-        // 検索ボックスの入力内容
-        const searchData = ref<SearchData>({
-            method: 'search',
-            age: ['A'],
-            item: ['description', 'commands'],
-            word: '',
-            sort: 'created_at',
-            order: 'asc'
-        })
-       
-        // プリセット検索APIを呼び出し、検索ボックスの内容に応じた値を取得
-        const getPresetData = async(postData: SearchData = searchData.value) => {
-            const url = registerPath +  'api/managePreset.php'
-            // プリセットを初期化
-            savedPromptList.value = []
-            await axios.get(url, {
-                params: postData
-            }).then(response => {
-                    if (response.data !== '') {
-                        savedPromptList.value = response.data
-                        revertDBData(savedPromptList.value)
-                        setImages(savedPromptList.value)
-                        setIsNsfw(savedPromptList.value)
-                    }
-                })
-                .catch(error => {
-                    console.log(error) 
-                })
-        }
-        
-        // コピーした際のアラートを設定
-        const alertText = ref<string>('') 
-        const setAlertText = (text: string) => alertText.value = text
-        
-        // ページ遷移用のURI
-        // テストサーバーも含める為パス名を取得して結合
-        const originPath = new URL(location.href).origin + location.pathname
-        
-        // ログインユーザーIDを取得
-        const user_id = ref<string>('')
-        const getUserInfo = (userId: string) => user_id.value = userId
-        
-
-        // 画面ロード時、APIからログインユーザーの登録プロンプト一覧を取得
-        onMounted(() => {
-            document.title = 'NovelAI プロンプトセーバー'
-            getPresetData()
-        })
-
-        return {
-            savedPromptList,
-            isDisplaySearchBox: isDisplaySearchBox,
-            selectedPreset,
-            selectedPresetIndex,
-            searchData: searchData,
-            alertText,
-            isRegisterMode,
-            originPath,
-            user_id,
-
-            selectPreset,
-            getPresetData,
-            setAlertText,
-            setRegisterMode,
-            getUserInfo,
-        }
-    }
-}
-</script>

--- a/src/assets/scss/savedPrompt.scss
+++ b/src/assets/scss/savedPrompt.scss
@@ -73,6 +73,14 @@
             font-size: 16px;
         }
     }
+    > dl > .btn-common.green {
+        display: block;
+        width: 180px;
+        margin: 8px auto;
+        padding: 8px;
+        font-size: 16px;
+        border-radius: 8px;
+    }
 }
 
 /*--------------------

--- a/src/components/AccountManageComponent.vue
+++ b/src/components/AccountManageComponent.vue
@@ -1,3 +1,83 @@
+<script setup lang="ts">
+import registerPath from '@/assets/ts/registerPath'
+import { AccountInfo } from '@/assets/ts/Interfaces/Index'
+import HeaderComponent from './HeaderComponent.vue'
+import '../assets/scss/manageAccount.scss'
+import axios from 'axios'
+import { ref, computed, watchEffect } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+router
+const currentURL = computed(() => route.path)
+
+// ログインページか登録ページかの判定
+const currentPath = ref<string>('')
+watchEffect(() => {
+    currentPath.value = currentURL.value.match(/login/) ? 'login' : 'register'
+})
+
+// 入力フォームのアカウント情報
+const account = ref<AccountInfo>({
+    method: '',
+    email: '',
+    user_id: '',
+    password: '',
+})
+
+// 登録ボタンが押された際、バリデーションを行いアカウント登録またはログイン
+const responseMessage = ref<string>('')
+const formUrl = registerPath + 'api/manageAccount.php'
+const regex = {
+    user_id: '^.{6,20}$',
+    password: '^([a-zA-Z0-9]{8,20})$'
+}
+
+const submitAccountData = async() => {
+    // 入力内容がパターンにマッチしない場合エラーメッセージを出力
+    if (!new RegExp(regex.user_id).test(account.value.user_id)) {
+        responseMessage.value = 'ユーザーIDの入力内容が空または不正です。'
+        return
+    }
+
+    if (!new RegExp(regex.password).test(account.value.password)) {
+        responseMessage.value = 'パスワードの入力内容が空または不正です。'
+        return
+    }
+
+    // バリデーションを通過したらAPIを叩いてユーザーデータを登録
+    const sendData = {...account.value}
+    sendData.method = currentPath.value
+
+    const formData = JSON.stringify(sendData)
+    axios.post(formUrl, formData).then((response) => {
+        // 返答でエラーが無い場合は指定ページにリダイレクト
+        if (!response.data.error) {
+            if (currentPath.value === 'register') {
+                // ログインページ遷移時メッセージと入力内容を初期化
+                responseMessage.value = ''
+                account.value.user_id = ''
+                account.value.password = ''
+                router.push('./login')
+            } else if (currentPath.value === 'login') {
+                router.push('./')
+            }
+        } else {
+            // エラーが返された場合は内容を画面に表示
+            responseMessage.value = response.data.content
+        }
+    }).catch(error => {
+        responseMessage.value = 'データベース接続に失敗しました。お手数ですが、時間を置いて再度お試しください。'
+        console.log(error)
+    })
+}
+
+// ログインユーザーIDを取得
+const user_id = ref<string>('')
+const getUserInfo = (userId: string) => user_id.value = userId;
+</script>
+
 <template lang="">
     <HeaderComponent @getUserInfo="getUserInfo"></HeaderComponent> 
     <main class="account-manage">
@@ -35,104 +115,3 @@
     </main>
     <router-view></router-view>
 </template>
-<script lang="ts">
-import registerPath from '@/assets/ts/registerPath'
-import { AccountInfo } from '@/assets/ts/Interfaces/Index'
-import HeaderComponent from './HeaderComponent.vue'
-import '../assets/scss/manageAccount.scss'
-import axios from 'axios'
-import { ref, computed, watchEffect } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
-
-export default {
-    components: {
-        HeaderComponent,
-    },
-    setup() {
-        const route = useRoute()
-        const router = useRouter()
-        router
-        const currentURL = computed(() => route.path)
-        
-        // ログインページか登録ページかの判定
-        const currentPath = ref<string>('')
-        watchEffect(() => {
-            currentPath.value = currentURL.value.match(/login/) ? 'login' : 'register'
-        })
-
-        // 入力フォームのアカウント情報
-        const account = ref<AccountInfo>({
-            method: '',
-            email: '',
-            user_id: '',
-            password: '',
-        })
-
-        // 登録ボタンが押された際、バリデーションを行いアカウント登録またはログイン
-        const responseMessage = ref<string>('')
-        const formUrl = registerPath + 'api/manageAccount.php'
-        const regex = {
-            user_id: '^.{6,20}$',
-            password: '^([a-zA-Z0-9]{8,20})$'
-        }
-
-        const submitAccountData = async() => {
-            // 入力内容がパターンにマッチしない場合エラーメッセージを出力
-            if (!new RegExp(regex.user_id).test(account.value.user_id)) {
-                responseMessage.value = 'ユーザーIDの入力内容が空または不正です。'
-                return
-            }
-
-            if (!new RegExp(regex.password).test(account.value.password)) {
-                responseMessage.value = 'パスワードの入力内容が空または不正です。'
-                return
-            }
-
-            // バリデーションを通過したらAPIを叩いてユーザーデータを登録
-            const sendData = {...account.value}
-            sendData.method = currentPath.value
-
-            const formData = JSON.stringify(sendData)
-            axios.post(formUrl, formData).then((response) => {
-                // 返答でエラーが無い場合は指定ページにリダイレクト
-                if (!response.data.error) {
-                    if (currentPath.value === 'register') {
-                        // ログインページ遷移時メッセージと入力内容を初期化
-                        responseMessage.value = ''
-                        account.value.user_id = ''
-                        account.value.password = ''
-                        router.push('./login')
-                    } else if (currentPath.value === 'login') {
-                        router.push('./')
-                    }
-                } else {
-                    // エラーが返された場合は内容を画面に表示
-                    responseMessage.value = response.data.content
-                }
-            }).catch(error => {
-                responseMessage.value = 'データベース接続に失敗しました。お手数ですが、時間を置いて再度お試しください。'
-                console.log(error)
-            })
-        }
-
-        // ログインユーザーIDを取得
-        const user_id = ref<string>('')
-        const getUserInfo = (userId: string) => user_id.value = userId;
-
-        return {
-            currentURL,
-            currentPath,
-            account,
-            user_id,
-            responseMessage,
-            regex,
-
-            submitAccountData,
-            getUserInfo,
-        }
-    }
-}
-</script>
-<style lang="">
-    
-</style>

--- a/src/components/HeaderComponent.vue
+++ b/src/components/HeaderComponent.vue
@@ -1,3 +1,47 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import registerPath from '@/assets/ts/registerPath'
+import '../assets/scss/header.scss'
+import axios from 'axios'
+
+interface Emits { (e: 'getUserInfo', userId: string): string }
+const emit = defineEmits<Emits>()
+
+// ハンバーガーメニューの表示状態
+const isOpenHBGMenu = ref<boolean>(false)
+
+// ページ遷移用のURI
+// テストサーバーも含める為パス名を取得して結合
+const originPath = new URL(location.href).origin + location.pathname
+
+// ログアウトリンクが押された場合APIに伝える
+const formUrl = registerPath + 'api/manageAccount.php'
+const execLogout = async() => {
+    const formData = JSON.stringify({
+        method: 'logout',
+        user_id: user_id.value,
+    })
+    await axios.post(formUrl, formData).catch((error) => {
+        console.log(error)
+    })
+}
+
+// 画面読み込み時にログインユーザーIDを取得
+const user_id = ref<string>('')
+const getUserInfo = async() => {
+    const url = registerPath + 'api/manageAccount.php'
+    axios.post(url, {
+        method: 'getUserData'
+    })
+        .then(response => {
+            user_id.value = response.data.user_id
+            emit('getUserInfo', user_id.value)
+        })
+        .catch(error => console.log(error))
+}
+onMounted(() => getUserInfo())
+</script>
+
 <template>
     <header class="header">
         <h1><a href="https://novelai.net/image">NovelAI</a> プロンプトジェネレーター</h1>
@@ -28,56 +72,3 @@
         </div>
     </header>
 </template>
-<script lang="ts">
-import { ref, onMounted } from 'vue'
-import registerPath from '@/assets/ts/registerPath'
-import '../assets/scss/header.scss'
-import axios from 'axios'
-
-export default {
-    emits: ['getUserInfo'],
-    setup(props: any, context: any) {
-        const isOpenHBGMenu = ref<boolean>(false)
-
-        // ページ遷移用のURI
-        // テストサーバーも含める為パス名を取得して結合
-        const originPath = new URL(location.href).origin + location.pathname
-
-        // ログアウトリンクが押された場合APIに伝える
-        const formUrl = registerPath + 'api/manageAccount.php'
-        const execLogout = async() => {
-            const formData = JSON.stringify({
-                method: 'logout',
-                user_id: user_id.value,
-            })
-            await axios.post(formUrl, formData).catch((error) => {
-                console.log(error)
-            })
-        }
-
-        // 画面読み込み時にログインユーザーIDを取得
-        const user_id = ref<string>('')
-        const getUserInfo = async() => {
-            const url = registerPath + 'api/manageAccount.php'
-            axios.post(url, {
-                method: 'getUserData'
-            })
-                .then(response => {
-                    user_id.value = response.data.user_id
-                    context.emit('getUserInfo', user_id.value)
-                })
-                .catch(error => console.log(error))
-        }
-        onMounted(() => getUserInfo())
-
-
-        return {
-            user_id,
-            isOpenHBGMenu: isOpenHBGMenu,
-            originPath,
-
-            execLogout,
-        }
-    }
-}
-</script>

--- a/src/components/HeaderComponent.vue
+++ b/src/components/HeaderComponent.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import registerPath from '@/assets/ts/registerPath'
-import '../assets/scss/header.scss'
+import '@/assets/scss/header.scss'
 import axios from 'axios'
 
 interface Emits { (e: 'getUserInfo', userId: string): string }

--- a/src/components/generator/SetPromptComponent.vue
+++ b/src/components/generator/SetPromptComponent.vue
@@ -2,7 +2,7 @@
 import { SetPrompt, ColorVariation } from '@/assets/ts/Interfaces/Index'
 import { ref, computed, watchEffect } from 'vue'
 import draggable from 'vuedraggable'
-import '../../assets/scss/promptGenerator.scss'
+import '@/assets/scss/promptGenerator.scss'
 
 interface Props {
     setPromptList: SetPrompt[],

--- a/src/components/generator/SetPromptComponent.vue
+++ b/src/components/generator/SetPromptComponent.vue
@@ -1,3 +1,123 @@
+<script setup lang="ts">
+import { SetPrompt, ColorVariation } from '@/assets/ts/Interfaces/Index'
+import { ref, computed, watchEffect } from 'vue'
+import draggable from 'vuedraggable'
+import '../../assets/scss/promptGenerator.scss'
+
+interface Props {
+    setPromptList: SetPrompt[],
+    hoverPromptName?: string,
+}
+
+interface Emits {
+    (e: 'updateSetPrompt', childSetPrompt: SetPrompt[]): SetPrompt[],
+    (e: 'addManualPrompt', uploadPromptName: string, enhanceCount: number): void,
+    (e: 'unSelectedPrompt', promptListIndex: string | null): void,
+    (e: 'openSaveModal', modalState: boolean, output: string): void,
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<Emits>()
+
+const setPrompt = ref<SetPrompt[]>([])
+watchEffect(() => setPrompt.value = props.setPromptList)
+// カーソルを合わせているプロンプトの英語名
+const hoverPrompt = computed(() => props.hoverPromptName)
+
+// 親子間のプロンプト設定を同期させる
+watchEffect(() => emit('updateSetPrompt', setPrompt.value))
+
+// 手動入力でのプロンプトの追加
+const manualInput = ref<string>('')
+const addManualPrompt = (input: string, enhanceCount: number = 0): void => {
+    emit('addManualPrompt', input, enhanceCount)
+}
+
+// プロンプト設定欄からボタンが押されたプロンプトを削除
+const deleteSetPrompt = (index: number) => {
+    // 親コンポーネントにプロンプトのインデックスを伝えて選択を解除
+    emit('unSelectedPrompt', setPrompt.value[index].index)
+    
+    setPrompt.value.splice(index, 1)
+}
+
+// カラーバリエーションのあるプロンプトで色付きが選択された場合プロンプト名を変換
+const selectedColor = ref<ColorVariation>({prompt: '', jp: ''})
+const changePromptColor = (colorTag: ColorVariation, index: number): void => {
+    // 一度表示名とタグ名をリセット
+    const braceIndex = setPrompt.value[index].jp.indexOf('(')
+    setPrompt.value[index].output_prompt = setPrompt.value[index].tag
+
+    if (braceIndex !== -1) {
+        setPrompt.value[index].jp = setPrompt.value[index].jp.substring(0, braceIndex-1)
+    }
+    if (colorTag.prompt !== 'none')  {
+        setPrompt.value[index].jp = setPrompt.value[index].jp + ' (' + colorTag.jp + ')'
+        setPrompt.value[index].output_prompt = colorTag.prompt + ' ' + setPrompt.value[index].tag
+    }
+    selectedColor.value = {prompt: '', jp: ''}
+}
+
+// 生成されたNovelAI形式のプロンプト
+const outputPrompt = ref('')
+const enhanceBraceText = ref<string>('( )に変換')
+// キューにセットされているタグをNovelAIで使える形に変換する
+const convertToOutputPrompt = (setPrompt: SetPrompt[]): void => {
+    const text = ref('')
+    
+    setPrompt.map(prompt => {
+        // タグの付与
+        // 強化値が0の場合そのまま追加
+        if (prompt.enhance === 0) {
+            text.value += prompt.output_prompt
+        } else if (prompt.enhance > 0) {
+            // 強化値が1以上の場合前後に{}または()を数値分追加
+            if (enhanceBraceText.value === '( )に変換') {
+                text.value += '{'.repeat(prompt.enhance) + prompt.output_prompt + '}'.repeat(prompt.enhance) 
+            } else if (enhanceBraceText.value === '{ }に変換') {
+                text.value += '('.repeat(prompt.enhance) + prompt.output_prompt + ')'.repeat(prompt.enhance) 
+            }
+        } else if (prompt.enhance < 0) {
+            // 強化値が-1以下の場合前後に[]を数値分追加
+            const num = prompt.enhance * -1
+            text.value += '['.repeat(num) + prompt.output_prompt + ']'.repeat(num)
+        }
+        text.value += ', '
+    })
+    
+    outputPrompt.value = text.value
+}
+
+// 強化値の()と{}を切り替える
+const toggleEnhanceBrace = () => {
+    if (enhanceBraceText.value === '( )に変換') {
+        enhanceBraceText.value = '{ }に変換'
+        outputPrompt.value = outputPrompt.value.replaceAll(/\{/g, '(').replaceAll(/\}/g, ')')
+    } else {
+        enhanceBraceText.value = '( )に変換'
+        outputPrompt.value = outputPrompt.value.replaceAll(/\(/g, '{').replaceAll(/\)/g, '}')
+    }
+}
+
+// DB保存用のモーダルを開く
+const openSaveModal = (promptList: SetPrompt[], modalState: boolean): void => {
+    convertToOutputPrompt(promptList)
+    emit('openSaveModal', modalState, outputPrompt.value)
+}
+
+// プロンプトをコピーした際のアラート
+const copyAlertText = ref('')
+// プロンプトをクリップボードにコピーする
+const copyToClipboard = (text: string): void => {
+    navigator.clipboard.writeText(text)
+    copyAlertText.value = 'クリップボードにコピーしました。'
+}
+
+// 出力値の編集状態
+const isEditPrompt = ref<boolean>(false)
+</script>
+
 <template>
     <div class="prompt-settings">
         <div class="description">
@@ -74,143 +194,3 @@
         </div>
     </div>
 </template>
-<script lang="ts">
-import { SetPrompt, ColorVariation } from '@/assets/ts/Interfaces/Index'
-import { ref, computed, watchEffect } from 'vue'
-import draggable from 'vuedraggable'
-import '../../assets/scss/promptGenerator.scss'
-
-export default {
-    components: {
-        draggable,
-    },
-    props: {
-        setPromptList: Object,
-        hoverPromptName: String,
-    },
-    emits: [
-        'updateSetPrompt',
-        'addManualPrompt', 
-        'unSelectedPrompt', 
-        'openSaveModal'
-    ],
-    setup(props: any, context: any) {
-        const setPrompt = ref<SetPrompt[]>([])
-        watchEffect(() => setPrompt.value = props.setPromptList)
-        // カーソルを合わせているプロンプトの英語名
-        const hoverPrompt = computed(() => props.hoverPromptName)
-
-        // 親子間のプロンプト設定を同期させる
-        watchEffect(() => context.emit('updateSetPrompt', setPrompt.value))
-
-        // 手動入力でのプロンプトの追加
-        const manualInput = ref<string>('')
-        const addManualPrompt = (input: string, enhanceCount: number = 0): void => {
-            context.emit('addManualPrompt', input, enhanceCount)
-        }
-
-        // プロンプト設定欄からボタンが押されたプロンプトを削除
-        const deleteSetPrompt = (index: number) => {
-            // プロンプト一覧から選択したプロンプトの場合親コンポーネントに伝えて選択を解除
-            if (setPrompt.value[index].index !== null) {
-                context.emit('unSelectedPrompt', setPrompt.value[index].index)
-            }
-            setPrompt.value.splice(index, 1)
-        }
-
-        // カラーバリエーションのあるプロンプトで色付きが選択された場合プロンプト名を変換
-        const selectedColor = ref<ColorVariation>({prompt: '', jp: ''})
-        const changePromptColor = (colorTag: ColorVariation, index: number): void => {
-            // 一度表示名とタグ名をリセット
-            const braceIndex = setPrompt.value[index].jp.indexOf('(')
-            setPrompt.value[index].output_prompt = setPrompt.value[index].tag
-
-            if (braceIndex !== -1) {
-                setPrompt.value[index].jp = setPrompt.value[index].jp.substring(0, braceIndex-1)
-            }
-            if (colorTag.prompt !== 'none')  {
-                setPrompt.value[index].jp = setPrompt.value[index].jp + ' (' + colorTag.jp + ')'
-                setPrompt.value[index].output_prompt = colorTag.prompt + ' ' + setPrompt.value[index].tag
-            }
-            selectedColor.value = {prompt: '', jp: ''}
-        }
-
-        // 生成されたNovelAI形式のプロンプト
-        const outputPrompt = ref('')
-        const enhanceBraceText = ref<string>('( )に変換')
-        // キューにセットされているタグをNovelAIで使える形に変換する
-        const convertToOutputPrompt = (setPrompt: SetPrompt[]): void => {
-            const text = ref('')
-            
-            setPrompt.map(prompt => {
-                // タグの付与
-                // 強化値が0の場合そのまま追加
-                if (prompt.enhance === 0) {
-                    text.value += prompt.output_prompt
-                } else if (prompt.enhance > 0) {
-                    // 強化値が1以上の場合前後に{}または()を数値分追加
-                    if (enhanceBraceText.value === '( )に変換') {
-                        text.value += '{'.repeat(prompt.enhance) + prompt.output_prompt + '}'.repeat(prompt.enhance) 
-                    } else if (enhanceBraceText.value === '{ }に変換') {
-                        text.value += '('.repeat(prompt.enhance) + prompt.output_prompt + ')'.repeat(prompt.enhance) 
-                    }
-                } else if (prompt.enhance < 0) {
-                    // 強化値が-1以下の場合前後に[]を数値分追加
-                    const num = prompt.enhance * -1
-                    text.value += '['.repeat(num) + prompt.output_prompt + ']'.repeat(num)
-                }
-                text.value += ', '
-            })
-            
-            outputPrompt.value = text.value
-        }
-
-        // 強化値の()と{}を切り替える
-        const toggleEnhanceBrace = () => {
-            if (enhanceBraceText.value === '( )に変換') {
-                enhanceBraceText.value = '{ }に変換'
-                outputPrompt.value = outputPrompt.value.replaceAll(/\{/g, '(').replaceAll(/\}/g, ')')
-            } else {
-                enhanceBraceText.value = '( )に変換'
-                outputPrompt.value = outputPrompt.value.replaceAll(/\(/g, '{').replaceAll(/\)/g, '}')
-            }
-        }
-
-        // DB保存用のモーダルを開く
-        const openSaveModal = (promptList: SetPrompt[], modalState: boolean): void => {
-            convertToOutputPrompt(promptList)
-            context.emit('openSaveModal', modalState, outputPrompt.value)
-        }
-        
-        // プロンプトをコピーした際のアラート
-        const copyAlertText = ref('')
-        // プロンプトをクリップボードにコピーする
-        const copyToClipboard = (text: string): void => {
-            navigator.clipboard.writeText(text)
-            copyAlertText.value = 'クリップボードにコピーしました。'
-        }
-
-        // 出力値の編集状態
-        const isEditPrompt = ref<boolean>(false)
-
-        return {
-            setPrompt,
-            hoverPrompt,
-            manualInput: manualInput,
-            selectedColor: selectedColor,
-            outputPrompt: outputPrompt,
-            enhanceBraceText: enhanceBraceText,
-            copyAlertText: copyAlertText,
-            isEditPrompt: isEditPrompt,
-
-            addManualPrompt,
-            deleteSetPrompt,
-            changePromptColor,
-            convertToOutputPrompt,
-            toggleEnhanceBrace,
-            openSaveModal,
-            copyToClipboard,
-        }
-    } 
-}
-</script>

--- a/src/components/saver/SearchBoxComponent.vue
+++ b/src/components/saver/SearchBoxComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import '../../assets/scss/savedPrompt.scss'
+import '@/assets/scss/savedPrompt.scss'
 import { SearchData } from '@/assets/ts/Interfaces/Index'
 import { ref } from 'vue'
 

--- a/src/components/saver/SearchBoxComponent.vue
+++ b/src/components/saver/SearchBoxComponent.vue
@@ -1,3 +1,24 @@
+<script setup lang="ts">
+import '../../assets/scss/savedPrompt.scss'
+import { SearchData } from '@/assets/ts/Interfaces/Index'
+import { ref } from 'vue'
+
+interface Props { searchBoxData: SearchData }
+interface Emits {
+    (e: 'getPresetData', postData: SearchData): Promise<void>,
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+// 検索ボックスの入力内容
+const searchData = ref<SearchData>(props.searchBoxData)
+
+const execSearch = () => {
+    emit('getPresetData', searchData.value)
+}
+</script>
+
 <template lang="">
     <div class="search-box">
         <dl>
@@ -63,38 +84,3 @@
         </dl>
     </div>
 </template>
-<script lang="ts">
-import '../../assets/scss/savedPrompt.scss'
-import { SearchData } from '@/assets/ts/Interfaces/Index'
-import { ref } from 'vue'
-
-export default {
-    emits: ['getPresetData',],
-    props: {
-        searchBoxData: Object,
-    },
-    setup(props: any, context: any) {
-        // 検索ボックスの入力内容
-        const searchData = ref<SearchData>(props.searchBoxData)
-
-        const execSearch = () => {
-            context.emit('getPresetData', searchData.value)
-        }
-
-        return {
-            searchData,
-            execSearch,
-        }
-    }
-}
-</script>
-<style lang="scss" scoped>
-.btn-common.green {
-    display: block;
-    width: 180px;
-    margin: 8px auto;
-    padding: 8px;
-    font-size: 16px;
-    border-radius: 8px;
-}
-</style>

--- a/src/components/saver/SelectedPresetComponent.vue
+++ b/src/components/saver/SelectedPresetComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import '../../assets/scss/savedPrompt.scss'
+import '@/assets/scss/savedPrompt.scss'
 import { PresetDetail } from '@/assets/ts/Interfaces/Index'
 import { ref, watchEffect } from 'vue'
 

--- a/src/components/saver/SelectedPresetComponent.vue
+++ b/src/components/saver/SelectedPresetComponent.vue
@@ -1,3 +1,56 @@
+<script setup lang="ts">
+import '../../assets/scss/savedPrompt.scss'
+import { PresetDetail } from '@/assets/ts/Interfaces/Index'
+import { ref, watchEffect } from 'vue'
+
+interface Props { selected: PresetDetail }
+interface Emits {
+    (e: 'setAlertText', text: string): string,
+    (e: 'setRegisterMode', state: boolean, mode: string): void,
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const preset = ref<PresetDetail>(props.selected)
+watchEffect(() => preset.value = props.selected)
+
+// 強化値の{}と()を切り替える
+const enhanceBraceMessage = ref<string>('( )に変換')
+const toggleEnhanceBrace = () => {
+    if (enhanceBraceMessage.value === '( )に変換') {
+        enhanceBraceMessage.value = '{ }に変換'
+        preset.value.commands = preset.value.commands.replaceAll(/\{/g, '(').replaceAll(/\}/g, ')')
+        preset.value.commands_ban = preset.value.commands_ban.replaceAll(/\{/g, '(').replaceAll(/\}/g, ')')
+    } else {
+        enhanceBraceMessage.value = '( )に変換'
+        preset.value.commands = preset.value.commands.replaceAll(/\(/g, '{').replaceAll(/\)/g, '}')
+        preset.value.commands_ban = preset.value.commands_ban.replaceAll(/\(/g, '{').replaceAll(/\)/g, '}')
+    }
+}
+
+// クリックした文字列をコピーする
+const alertText = ref<string>('')
+const copyText = (text: string, name: string) => {
+    const href = location.href.substring(0,5)
+    if (href === 'https') {
+        navigator.clipboard.writeText(text)
+    } else if (href === 'http:') {
+        const input = document.createElement('input')
+        document.body.appendChild(input)
+        input.value = text
+        input.select()
+        document.execCommand('copy')
+        document.body.removeChild(input)
+    }
+    alertText.value = preset.value.description + 'の' + name + 'をコピーしました。'
+    emit('setAlertText', alertText.value)
+}
+
+// 編集ボタンが押された場合プリセット詳細画面を編集画面に切り替える
+const setRegisterMode = (state: boolean, mode: string) => emit('setRegisterMode', state, mode)
+</script>
+
 <template lang="">
     <section class="preset-detail">
         <div v-if="'preset_id' in preset">
@@ -71,64 +124,3 @@
         </div>
     </section>
 </template>
-<script lang="ts">
-import '../../assets/scss/savedPrompt.scss'
-import { PresetDetail } from '@/assets/ts/Interfaces/Index'
-import { ref, watchEffect } from 'vue'
-
-export default {
-    props: {
-        selected: Object,
-    },
-    emits: ['setAlertText', 'setRegisterMode', ],
-    setup(props:any, context:any) {
-        const preset = ref<PresetDetail>(props.selected)
-        watchEffect(() => preset.value = props.selected)
-
-        // 強化値の{}と()を切り替える
-        const enhanceBraceMessage = ref<string>('( )に変換')
-        const toggleEnhanceBrace = () => {
-            if (enhanceBraceMessage.value === '( )に変換') {
-                enhanceBraceMessage.value = '{ }に変換'
-                preset.value.commands = preset.value.commands.replaceAll(/\{/g, '(').replaceAll(/\}/g, ')')
-                preset.value.commands_ban = preset.value.commands_ban.replaceAll(/\{/g, '(').replaceAll(/\}/g, ')')
-            } else {
-                enhanceBraceMessage.value = '( )に変換'
-                preset.value.commands = preset.value.commands.replaceAll(/\(/g, '{').replaceAll(/\)/g, '}')
-                preset.value.commands_ban = preset.value.commands_ban.replaceAll(/\(/g, '{').replaceAll(/\)/g, '}')
-            }
-        }
-
-        // クリックした文字列をコピーする
-        const alertText = ref<string>('')
-        const copyText = (text: string, name: string) => {
-            const href = location.href.substring(0,5)
-            if (href === 'https') {
-                navigator.clipboard.writeText(text)
-            } else if (href === 'http:') {
-                const input = document.createElement('input')
-                document.body.appendChild(input)
-                input.value = text
-                input.select()
-                document.execCommand('copy')
-                document.body.removeChild(input)
-            }
-            alertText.value = preset.value.description + 'の' + name + 'をコピーしました。'
-            context.emit('setAlertText', alertText.value)
-        }
-
-        // 編集ボタンが押された場合プリセット詳細画面を編集画面に切り替える
-        const setRegisterMode = (state: boolean, mode: string) => context.emit('setRegisterMode', state, mode)
-
-        return {
-            preset,
-            enhanceBraceMessage: enhanceBraceMessage,
-            alertText,
-
-            toggleEnhanceBrace,
-            copyText,
-            setRegisterMode,
-        }
-    }
-}
-</script>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,7 +1,7 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
-import PromptGenerator from './PromptGenerator.vue'
-import SavedPrompt from './SavedPrompt.vue'
-import AccountManage from './components/AccountManageComponent.vue'
+import PromptGenerator from '@/PromptGenerator.vue'
+import SavedPrompt from '@/SavedPrompt.vue'
+import AccountManage from '@/AccountManager.vue'
 const routes = [
     {
         path: '/', 


### PR DESCRIPTION
対応に当たってEslintなどから理不尽に怒られたので以下それの対策
- package.jsonのeslintConfigに以下を追加
rules内：
        "no-unused-vars": "off",
        "vue/no-unused-vars": "off",
        "vue/script-setup-uses-vars": "off",
        "@typescript-eslint/no-unused-vars": ["error"]
env内：
        "vue/setup-compiler-macros": true

- VSCodeの拡張機能のVeturはVue2用っぽいのでアンインストールし、代わりにVolarを導入

その他今回の変更とは関係ないけど発見したバグ：
- プロンプトアップロード時、目の色の設定部分のみ選択が適用されない
- 例えばblack eyesと入力してアップロードしても、該当のプロンプトがプロンプト一覧にあるのに手動入力として扱われる